### PR TITLE
Fix: progress icon spin in combo box

### DIFF
--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -12,6 +12,7 @@ gateway.connector.view.login.cli.downloader.dialog.title=Authenticate and setup 
 gateway.connector.view.coder.workspaces.next.text=Select IDE and Project
 gateway.connector.view.coder.workspaces.choose.text=Choose a workspace
 gateway.connector.view.coder.remoteproject.loading.text=Retrieving products...
+gateway.connector.view.coder.remoteproject.ide.error.text=Could not retrieve any IDE for workspace {0} because an error was encountered
 gateway.connector.view.coder.remoteproject.next.text=Download and Start IDE
 gateway.connector.view.coder.remoteproject.choose.text=Choose IDE and project for workspace {0}
 gateway.connector.recentconnections.title=Recent Coder Workspaces


### PR DESCRIPTION
- the progress icon in the IDE selection combo box was not
  spinning while IDEs were loading.
- there were two reasons:
    1. the combobox did not enable animated icons in the
    renderer
    2. the cell renderer implementation did not repaint
   the icon
- resolves #4

- the IDEs combobox is no longer stuck with the text "Retrieving
  products.." if an exception happens in the code.
- instead, exceptions are handled a new custom combo box renderer
  is installed that tells the user that an error was encountered
  while retrieving the IDEs.
- resolves #10