### PR TITLE
Impl: action to open dashboard in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - warning system when plugin might not be compatible with Coder REST API
 - a `Create workspace` button which links to Coder's templates page
 - workspace icons
+- quick toolbar action to open Coder Dashboard in the browser
 
 ### Changed
 - redesigned the information&warning banner. Messages can now include hyperlinks

--- a/src/main/kotlin/com/coder/gateway/icons/CoderIcons.kt
+++ b/src/main/kotlin/com/coder/gateway/icons/CoderIcons.kt
@@ -8,6 +8,7 @@ object CoderIcons {
 
     val OPEN_TERMINAL = IconLoader.getIcon("open_terminal.svg", javaClass)
 
+    val HOME = IconLoader.getIcon("homeFolder.svg", javaClass)
     val CREATE = IconLoader.getIcon("create.svg", javaClass)
     val RUN = IconLoader.getIcon("run.svg", javaClass)
     val STOP = IconLoader.getIcon("stop.svg", javaClass)

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -125,6 +125,7 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
         }
     }
 
+    private val goToDashboardAction = GoToDashboardAction()
     private val startWorkspaceAction = StartWorkspaceAction()
     private val stopWorkspaceAction = StopWorkspaceAction()
     private val updateWorkspaceTemplateAction = UpdateWorkspaceTemplateAction()
@@ -134,6 +135,7 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
         .disableAddAction()
         .disableRemoveAction()
         .disableUpDownActions()
+        .addExtraAction(goToDashboardAction)
         .addExtraAction(startWorkspaceAction)
         .addExtraAction(stopWorkspaceAction)
         .addExtraAction(updateWorkspaceTemplateAction)
@@ -183,6 +185,12 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
     override val previousActionText = IdeBundle.message("button.back")
     override val nextActionText = CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.next.text")
 
+    private inner class GoToDashboardAction : AnActionButton(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.dashboard.text"), CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.dashboard.text"), CoderIcons.HOME) {
+        override fun actionPerformed(p0: AnActionEvent) {
+            BrowserUtil.browse(coderClient.coderURL)
+        }
+    }
+
     private inner class StartWorkspaceAction : AnActionButton(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.start.text"), CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.start.text"), CoderIcons.RUN) {
         override fun actionPerformed(p0: AnActionEvent) {
             if (tableOfWorkspaces.selectedObject != null) {
@@ -221,12 +229,6 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
         }
     }
 
-    private inner class CreateWorkspaceAction : AnActionButton(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.create.text"), CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.create.text"), CoderIcons.CREATE) {
-        override fun actionPerformed(p0: AnActionEvent) {
-            BrowserUtil.browse(coderClient.coderURL.toURI().resolve("/templates"))
-        }
-    }
-
     private inner class StopWorkspaceAction : AnActionButton(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.stop.text"), CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.stop.text"), CoderIcons.STOP) {
         override fun actionPerformed(p0: AnActionEvent) {
             if (tableOfWorkspaces.selectedObject != null) {
@@ -242,6 +244,12 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
                     }
                 }
             }
+        }
+    }
+
+    private inner class CreateWorkspaceAction : AnActionButton(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.create.text"), CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.create.text"), CoderIcons.CREATE) {
+        override fun actionPerformed(p0: AnActionEvent) {
+            BrowserUtil.browse(coderClient.coderURL.toURI().resolve("/templates"))
         }
     }
 
@@ -265,8 +273,8 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
     }
 
     private fun updateWorkspaceActions() {
-        createWorkspaceAction.isEnabled = true
-
+        goToDashboardAction.isEnabled = coderClient.isReady
+        createWorkspaceAction.isEnabled = coderClient.isReady
         when (tableOfWorkspaces.selectedObject?.agentStatus) {
             RUNNING -> {
                 startWorkspaceAction.isEnabled = false
@@ -380,6 +388,7 @@ class CoderWorkspacesStepView(val enableNextButtonCallback: (Boolean) -> Unit) :
         cs.launch {
             ProgressManager.getInstance().run(authTask)
         }
+        updateWorkspaceActions()
         triggerWorkspacePolling()
     }
 

--- a/src/main/resources/homeFolder.svg
+++ b/src/main/resources/homeFolder.svg
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#6E6E6E" d="M9,13 L9,10 L7,10 L7,13 L4,13 L4,7 L12,7 L12,13 L9,13 Z" />
+        <polygon fill="#6E6E6E" points="8 2 15 8 1 8" />
+    </g>
+</svg>

--- a/src/main/resources/homeFolder_dark.svg
+++ b/src/main/resources/homeFolder_dark.svg
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#AFB1B3" d="M9,13 L9,10 L7,10 L7,13 L4,13 L4,7 L12,7 L12,13 L9,13 Z" />
+        <polygon fill="#AFB1B3" points="8 2 15 8 1 8" />
+    </g>
+</svg>

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -11,6 +11,7 @@ gateway.connector.view.coder.workspaces.connect.text=Connect
 gateway.connector.view.coder.workspaces.cli.downloader.dialog.title=Authenticate and setup Coder
 gateway.connector.view.coder.workspaces.cli.configssh.dialog.title=Coder Config SSH
 gateway.connector.view.coder.workspaces.next.text=Select IDE and Project
+gateway.connector.view.coder.workspaces.dashboard.text=Open Dashboard
 gateway.connector.view.coder.workspaces.start.text=Start Workspace
 gateway.connector.view.coder.workspaces.stop.text=Stop Workspace
 gateway.connector.view.coder.workspaces.update.text=Update Workspace Template


### PR DESCRIPTION
- new `go to dashboard` action
- fixed issue where `create workspaces` action button was always enabled, even when the plugin was not connected to any Coder deployment
- resolves #115