### PR TITLE
fix: do not warn on newer Coder versions

### DIFF
--- a/src/main/resources/version/CoderSupportedVersions.properties
+++ b/src/main/resources/version/CoderSupportedVersions.properties
@@ -1,2 +1,2 @@
 minCompatibleCoderVersion=0.12.9
-maxCompatibleCoderVersion=0.13.6
+maxCompatibleCoderVersion=1.0.0


### PR DESCRIPTION
We can revert this if we introduce significant breaking changes to the API