### PR TITLE
fix: support for remote development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+### Fixed
+- support for `Remote Development` in the Jetbrains IDE's  
+
 ## 2.1.4 - 2022-12-23
 
 ### Added

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,10 @@
     <depends>com.intellij.modules.platform</depends>
 
     <!-- TODO: enable this when https://youtrack.jetbrains.com/issue/GTW-1528/Plugin-depends-on-unknown-plugin-comjetbrainsgateway is fixed-->
-    <!-- depends>com.jetbrains.gateway</depends>-->
+    <!-- <depends>com.jetbrains.gateway</depends>-->
+
+    <!-- we trick Gateway into no longer rasing the unknown module error by marking the dependency optional-->
+    <depends optional="true">com.jetbrains.gateway</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.coder.gateway.sdk.CoderRestClientService"></applicationService>


### PR DESCRIPTION
- professional versions for Jetbrains IDE's come with Gateway preinstalled as a "Remote Development" plugin.
- this issue was initially reported by https://github.com/coder/coder/issues/5812