### PR TITLE
Merge `eap`  branch back into main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Run plugin build
       - name: Run Build
-        run: ./gradlew clean buildPlugin
+        run: ./gradlew clean buildPlugin --info
 
 # until https://github.com/JetBrains/gradle-intellij-plugin/issues/1027 is solved
 
@@ -151,6 +151,7 @@ jobs:
         run: |
           gh release create v${{ needs.build.outputs.version }} \
             --draft \
+            --target main \
             --title "v${{ needs.build.outputs.version }}" \
             --notes "$(cat << 'EOM'
           ${{ needs.build.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
-        run: ./gradlew publishPlugin
+        run: ./gradlew publishPlugin --info
 
       # Upload artifact as a release asset
       - name: Upload Release Asset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,43 @@
 ### Fixed
 - terminal link is now correct when host ends in `/`
 
+## 2.1.6-eap.0 - 2023-02-02
+
+### Fixed
+- improved resiliency and error handling when resolving installed IDE's
+
 ## 2.1.6 - 2023-02-01
 
 ### Fixed
 - improved resiliency and error handling when resolving installed IDE's
 
+## 2.1.5-eap.0 - 2023-01-24
+
+### Fixed
+- support for `Remote Development` in the Jetbrains IDE's
+
 ## 2.1.5 - 2023-01-24
 
 ### Fixed
 - support for `Remote Development` in the Jetbrains IDE's
+
+## 2.1.4-eap.0 - 2022-12-23
+Bug fixes and enhancements included in `2.1.4` release:
+
+### Added
+- ability to open a template in the Dashboard
+- ability to sort by workspace name, or by template name or by workspace status
+- a new token is requested when the one persisted is expired
+- support for re-using already installed IDE backends
+
+### Changed
+- renamed the plugin from `Coder Gateway` to `Gateway`
+- workspaces and agents are now resolved and displayed progressively
+
+### Fixed
+- icon rendering on `macOS`
+- `darwin` agents are now recognized as `macOS`
+- unsupported OS warning is displayed only for running workspaces
 
 ## 2.1.4 - 2022-12-23
 
@@ -33,6 +61,27 @@
 - icon rendering on `macOS`
 - `darwin` agents are now recognized as `macOS`
 - unsupported OS warning is displayed only for running workspaces
+
+## 2.1.3-eap.0 - 2022-12-12
+Bug fixes and enhancements included in `2.1.3` release:
+
+### Added
+- warning system when plugin might not be compatible with Coder REST API
+- a `Create workspace` button which links to Coder's templates page
+- workspace icons
+- quick toolbar action to open Coder Dashboard in the browser
+- custom user agent for the HTTP client
+
+### Changed
+- redesigned the information&warning banner. Messages can now include hyperlinks
+
+### Removed
+- connection handle window is no longer displayed
+
+### Fixed
+- outdated Coder CLI binaries are cleaned up
+- workspace status color style: running workspaces are green, failed ones should be red, everything else is gray
+- typos in plugin description
 
 ## 2.1.3 - 2022-12-09
 
@@ -53,6 +102,16 @@
 - outdated Coder CLI binaries are cleaned up
 - workspace status color style: running workspaces are green, failed ones should be red, everything else is gray
 - typos in plugin description
+
+## 2.1.2-eap.0 - 2022-11-29
+
+### Added
+- support for Gateway 2022.3 RC
+- upgraded support for the latest Coder REST API
+- support for latest Gateway 2022.2.x builds
+
+### Fixed
+- authentication flow is now done using HTTP headers
 
 ## 2.1.2 - 2022-11-23
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 // Configure project's dependencies
 repositories {
     mavenCentral()
-    maven(url = "https://www.jetbrains.com/intellij-repository/releases")
+    maven(url = "https://www.jetbrains.com/intellij-repository/snapshots")
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
@@ -145,10 +145,6 @@ tasks {
     publishPlugin {
         dependsOn("patchChangelog")
         token.set(System.getenv("PUBLISH_TOKEN"))
-        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 
     test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,13 @@ pluginName=coder-gateway
 pluginVersion=2.1.7
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222.3739.54
-pluginUntilBuild=222.*
+pluginSinceBuild=223.7571.70
+pluginUntilBuild=223.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # Gateway available build versions https://www.jetbrains.com/intellij-repository/snapshots and https://www.jetbrains.com/intellij-repository/releases
 platformType=GW
-platformVersion=222.4459.11-CUSTOM-SNAPSHOT
-instrumentationCompiler=222.4459.11-CUSTOM-SNAPSHOT
+platformVersion=223.8617.56-CUSTOM-SNAPSHOT
+instrumentationCompiler=223.8617.56-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
- main branch will now support Gateway 2022.3 versions