### PR TITLE
Use the same port for all executors

### DIFF
--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
@@ -140,7 +140,7 @@ class CoderLocateRemoteProjectStepView(private val disableNextAction: () -> Unit
 
         ideResolvingJob = cs.launch {
             try {
-                val executor = withTimeout(Duration.ofSeconds(60)) { createRemoteExecutor() }
+                val executor = withTimeout(Duration.ofSeconds(60)) { createRemoteExecutor(selectedWorkspace) }
                 retrieveIDES(executor, selectedWorkspace)
                 if (ComponentValidator.getInstance(tfProject).isEmpty) {
                     installRemotePathValidator(executor)
@@ -212,10 +212,10 @@ class CoderLocateRemoteProjectStepView(private val disableNextAction: () -> Unit
         })
     }
 
-    private suspend fun createRemoteExecutor(): HighLevelHostAccessor {
+    private suspend fun createRemoteExecutor(selectedWorkspace: WorkspaceAgentModel): HighLevelHostAccessor {
         return HighLevelHostAccessor.create(
             RemoteCredentialsHolder().apply {
-                setHost("coder.${wizard.selectedWorkspace?.name}")
+                setHost("coder.${selectedWorkspace.name}")
                 userName = "coder"
                 port = 22
                 authType = AuthType.OPEN_SSH


### PR DESCRIPTION
Gateway seems to keep a single process up (as indicated by the Coder proxy process persisting) and since we have one executor using port 22 and another using port 0 it was spawning two separate processes.

Using the same port causes it to use the existing process.  No idea if this will really affect much but I guess it does at least help guarantee that if you were able to list the editors you will be able to connect as well since it would use the same connection?

I also passed in the selected workspace, no real reason just felt like since it was already there and we use it in other function calls we might as well.  It does allow us to avoid the `?` I suppose.