### PR TITLE
Bump platform version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ pluginUntilBuild=231.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # Gateway available build versions https://www.jetbrains.com/intellij-repository/snapshots and https://www.jetbrains.com/intellij-repository/releases
 platformType=GW
-platformVersion=231.7665.28-CUSTOM-SNAPSHOT
-instrumentationCompiler=231.7665.28-CUSTOM-SNAPSHOT
+platformVersion=231.8109.172-CUSTOM-SNAPSHOT
+instrumentationCompiler=231.8109.172-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Seems we are not able to use the dev command without doing this as it hard aborts saying the version is too old.

Everything seems to run the same so I suppose no API changes were made.