### PR TITLE
Use expanded directory if available

### DIFF
--- a/src/main/kotlin/com/coder/gateway/sdk/v2/models/WorkspaceAgent.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/models/WorkspaceAgent.kt
@@ -20,11 +20,12 @@ data class WorkspaceAgent(
     @SerializedName("operating_system") val operatingSystem: String,
     @SerializedName("startup_script") val startupScript: String?,
     @SerializedName("directory") val directory: String?,
+    @SerializedName("expanded_directory") val expandedDirectory: String?,
     @SerializedName("version") val version: String,
     @SerializedName("apps") val apps: List<WorkspaceApp>,
     @SerializedName("latency") val derpLatency: Map<String, DERPRegion>?,
     @SerializedName("connection_timeout_seconds") val connectionTimeoutSeconds: Int,
-    @SerializedName("troubleshooting_url") val troubleshootingURL: String
+    @SerializedName("troubleshooting_url") val troubleshootingURL: String,
 )
 
 enum class WorkspaceAgentStatus {

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -655,7 +655,7 @@ class CoderWorkspacesStepView(val setNextButtonEnabled: (Boolean) -> Unit) : Cod
                         this.latestBuild.transition,
                         OS.from(agent.operatingSystem),
                         Arch.from(agent.architecture),
-                        agent.directory
+                        agent.expandedDirectory ?: agent.directory,
                     )
                     cs.launch(Dispatchers.IO) {
                         wm.templateIcon = iconDownloader.load(wm.templateIconPath, wm.name)


### PR DESCRIPTION
The JetBrains remote does not expand them so you get errors like "~/coder does not exist".