### PR TITLE
Bypass download if CLI version matches

### DIFF
--- a/src/main/kotlin/com/coder/gateway/sdk/CoderSemVer.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderSemVer.kt
@@ -14,7 +14,7 @@ class CoderSemVer(private val major: Long = 0, private val minor: Long = 0, priv
 
 
     override fun toString(): String {
-        return "CoderSemVer(major=$major, minor=$minor)"
+        return "CoderSemVer(major=$major, minor=$minor, patch=$patch)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -472,11 +472,9 @@ class CoderWorkspacesStepView(val setNextButtonEnabled: (Boolean) -> Unit) : Cod
                 // supported if the binary is downloaded from alternate sources.
                 // For CLIs without the JSON output flag we will fall back to
                 // the 304 method.
-                if (cliManager.version() != clientService.buildVersion) {
+                if (!cliManager.matchesVersion(clientService.buildVersion)) {
                     this.indicator.text = "Downloading Coder CLI..."
                     cliManager.downloadCLI()
-                } else {
-                    logger.info("Found existing binary at ${cliManager.localBinaryPath} with the expected version ${clientService.buildVersion}")
                 }
 
                 this.indicator.text = "Authenticating Coder CLI..."


### PR DESCRIPTION
This is a bit faster than waiting for a 304 but more importantly it works if the user customizes the download source to be a place that does not have the same etag support that Coder does.

The test bypasses Windows since we would need to create an executable there for the test.  We could split out the exec and the parsing although I am not sure it is worth the noise.  The part most likely to break between platforms is probably the exec, not the parsing?

We do indirectly test the version parsing on Windows with the test that goes against dev.coder.com.