### PR TITLE
Move template link to icon bar

### DIFF
--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -13,6 +13,7 @@ gateway.connector.view.coder.workspaces.connect.text=Connect
 gateway.connector.view.coder.workspaces.cli.downloader.dialog.title=Authenticate and setup Coder
 gateway.connector.view.coder.workspaces.next.text=Select IDE and project
 gateway.connector.view.coder.workspaces.dashboard.text=Open dashboard
+gateway.connector.view.coder.workspaces.template.text=View template
 gateway.connector.view.coder.workspaces.start.text=Start workspace
 gateway.connector.view.coder.workspaces.stop.text=Stop workspace
 gateway.connector.view.coder.workspaces.update.text=Update workspace template


### PR DESCRIPTION
This is because it is too easy to accidentally click when you just want to highlight the row.

The dashboard no longer seems to link that column so the experience will be consistent.

Closes https://github.com/coder/jetbrains-coder/issues/179.