### PR TITLE
Add support for Gateway 2023.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+### Added
+- Support for Gateway 2023.2.
+
 ## 2.4.0 - 2023-06-02
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 pluginGroup=com.coder.gateway
 pluginName=coder-gateway
 # SemVer format -> https://semver.org
-pluginVersion=2.4.0
+pluginVersion=2.5.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=223.7571.70
-pluginUntilBuild=231.*
+pluginUntilBuild=232.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # Gateway available build versions https://www.jetbrains.com/intellij-repository/snapshots and https://www.jetbrains.com/intellij-repository/releases
 platformType=GW
-platformVersion=231.8109.172-CUSTOM-SNAPSHOT
-instrumentationCompiler=231.8109.172-CUSTOM-SNAPSHOT
+platformVersion=232.8296.17-CUSTOM-SNAPSHOT
+instrumentationCompiler=232.8296.17-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/coder/gateway/sdk/TemplateIconDownloader.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/TemplateIconDownloader.kt
@@ -4,7 +4,7 @@ import com.coder.gateway.icons.CoderIcons
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.ui.JreHiDpiUtil
-import com.intellij.ui.paint.alignToInt
+import com.intellij.ui.paint.PaintUtil
 import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.ImageLoader
 import com.intellij.util.ui.ImageUtil
@@ -15,6 +15,16 @@ import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import java.net.URL
 import javax.swing.Icon
+
+fun alignToInt(g: Graphics) {
+    if (g !is Graphics2D) {
+        return
+    }
+
+    val rm = PaintUtil.RoundingMode.ROUND_FLOOR_BIAS
+    PaintUtil.alignTxToInt(g, null, true, true, rm)
+    PaintUtil.alignClipToInt(g, true, true, rm, rm)
+}
 
 @Service(Service.Level.APP)
 class TemplateIconDownloader {
@@ -45,6 +55,8 @@ class TemplateIconDownloader {
         return iconForChar(workspaceName.lowercase().first())
     }
 
+    // We could replace this with com.intellij.ui.icons.toRetinaAwareIcon at
+    // some point if we want to break support for Gateway < 232.
     private fun toRetinaAwareIcon(image: BufferedImage): Icon {
         val sysScale = JBUIScale.sysScale()
         return object : Icon {


### PR DESCRIPTION
com.intellij.ui.paint.alignToInt was made internal so the easiest way to maintain backwards compatibility seems to be to just copy it.

Closes https://github.com/coder/jetbrains-coder/issues/262.

Tested manually on Linux and Windows with the latest Gateway EAP (232.8296.17) and the previous version (231.8109.172).