### PR TITLE
Downgrade platformVersion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,4 +150,8 @@ tasks {
     test {
         useJUnitPlatform()
     }
+
+    runPluginVerifier {
+        ideVersions.set(properties("verifyVersions").split(","))
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,22 @@
 pluginGroup=com.coder.gateway
 pluginName=coder-gateway
 # SemVer format -> https://semver.org
-pluginVersion=2.5.0
+pluginVersion=2.5.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=223.7571.70
 pluginUntilBuild=232.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # Gateway available build versions https://www.jetbrains.com/intellij-repository/snapshots and https://www.jetbrains.com/intellij-repository/releases
+# The platform version must match the "since build" version while the
+# instrumentation version appears to be used in development.  The plugin
+# verifier should be used after bumping versions to ensure compatibility in the
+# range.
 platformType=GW
-platformVersion=232.8296.17-CUSTOM-SNAPSHOT
+platformVersion=223.7571.70-CUSTOM-SNAPSHOT
 instrumentationCompiler=232.8296.17-CUSTOM-SNAPSHOT
 platformDownloadSources=true
+verifyVersions=2022.3,2023.1,2023.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -33,8 +33,6 @@ import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.RightGap
 import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.util.maximumWidth
-import com.intellij.ui.util.minimumWidth
 import com.intellij.util.io.readText
 import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
@@ -182,8 +180,7 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                             toolTipText = "Querying workspace status..."
                         }
                     }).align(AlignX.LEFT).gap(RightGap.SMALL).applyToComponent {
-                        maximumWidth = JBUI.scale(16)
-                        minimumWidth = JBUI.scale(16)
+                        size = Dimension(JBUI.scale(16), JBUI.scale(16))
                     }
                     label(hostname.removePrefix("coder-jetbrains--")).applyToComponent {
                         font = JBFont.h3().asBold()


### PR DESCRIPTION
If you run the latest plugin on Gateway 231 you get an error about DeployWithDownload being void when the IDE is not already installed.

Reverting the platform version back to 231 makes the plugin work on both 231 and 232 (the current EAP).

Honestly I do not understand why this is necessary as the API here does not appear to have changed at all.

Upon doing some research though it appears that the platform version should match the "since build" version so I downgraded further.  It seems `minimumWidth` and `maximumWidth` are not available in that version so our plugin is currently broken there as well.  This is fixed by using `size` instead.

I think normally the plugin verifier would catch these things and I tried getting it working by specifying the versions to check but it seems to be bugged; the only errors it shows appear to be from a failure to properly resolve dependencies.