### PR TITLE
Do not remove CLI when going back to workspaces view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Unreleased
 
 ### Fixed
+- Inability to connect to a workspace after going back to the workspaces view.
+
+### Fixed
 - Inability to download new editors in older versions of Gateway.
 
 ## 2.5.0 - 2023-06-29

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.coder.gateway
 pluginName=coder-gateway
 # SemVer format -> https://semver.org
-pluginVersion=2.5.1
+pluginVersion=2.5.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=223.7571.70

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -303,7 +303,6 @@ class CoderWorkspacesStepView(val setNextButtonEnabled: (Boolean) -> Unit) : Cod
     }
 
     override fun onInit(wizardModel: CoderWorkspacesWizardModel) {
-        cliManager = null
         tableOfWorkspaces.listTableModel.items = emptyList()
         if (localWizardModel.coderURL.isNotBlank() && localWizardModel.token != null) {
             triggerWorkspacePolling(true)


### PR DESCRIPTION
We set it when connecting so this results in no CLI being available (for example if you go back and select a different or even the same workspace).

Fixes #277.