### PR TITLE
Add extra help for certificate errors

### DIFF
--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -10,6 +10,10 @@ gateway.connector.view.login.token.label=Session Token:
 gateway.connector.view.coder.workspaces.header.text=Coder Workspaces
 gateway.connector.view.coder.workspaces.comment=Self-hosted developer workspaces in the cloud or on-premises. Coder empowers developers with secure, consistent, and fast developer workspaces.
 gateway.connector.view.coder.workspaces.connect.text=Connect
+gateway.connector.view.coder.workspaces.connect.text.comment=Please enter your deployment URL and press "{0}".
+gateway.connector.view.coder.workspaces.connect.text.disconnected=Disconnected
+gateway.connector.view.coder.workspaces.connect.text.connected=Connected to {0}
+gateway.connector.view.coder.workspaces.connect.text.connecting=Connecting to {0}...
 gateway.connector.view.coder.workspaces.cli.downloader.dialog.title=Authenticate and setup Coder
 gateway.connector.view.coder.workspaces.next.text=Select IDE and project
 gateway.connector.view.coder.workspaces.dashboard.text=Open dashboard
@@ -19,12 +23,19 @@ gateway.connector.view.coder.workspaces.stop.text=Stop workspace
 gateway.connector.view.coder.workspaces.update.text=Update workspace template
 gateway.connector.view.coder.workspaces.create.text=Create workspace
 gateway.connector.view.coder.workspaces.unsupported.os.info=Gateway supports only Linux machines. Support for macOS and Windows is planned.
-gateway.connector.view.coder.workspaces.invalid.coder.version=Could not parse Coder version {0}. Coder Gateway plugin might not be compatible with this version. <a href='https://coder.com/docs/coder-oss/latest/ides/gateway#creating-a-new-jetbrains-gateway-connection'>Connect to a Coder workspace manually</a>
-gateway.connector.view.coder.workspaces.unsupported.coder.version=Coder version {0} might not be compatible with this plugin version. <a href='https://coder.com/docs/coder-oss/latest/ides/gateway#creating-a-new-jetbrains-gateway-connection'>Connect to a Coder workspace manually</a>
+gateway.connector.view.coder.workspaces.invalid.coder.version=Could not parse Coder version {0}. Coder Gateway plugin might not be compatible with this version. <a href='https://coder.com/docs/v2/latest/ides/gateway#creating-a-new-jetbrains-gateway-connection'>Connect to a Coder workspace manually</a>
+gateway.connector.view.coder.workspaces.unsupported.coder.version=Coder version {0} might not be compatible with this plugin version. <a href='https://coder.com/docs/v2/latest/ides/gateway#creating-a-new-jetbrains-gateway-connection'>Connect to a Coder workspace manually</a>
+gateway.connector.view.workspaces.connect.failed=Connection to {0} failed. See above for details.
+gateway.connector.view.workspaces.connect.no-reason=No reason was provided.
+gateway.connector.view.workspaces.connect.access-denied=Access denied to {0}.
+gateway.connector.view.workspaces.connect.unknown-host=Unknown host {0}.
+gateway.connector.view.workspaces.connect.unexpected-exit=CLI exited unexpectedly with {0}.
 gateway.connector.view.workspaces.connect.unauthorized=Token was rejected by {0}; has your token expired?
 gateway.connector.view.workspaces.connect.timeout=Unable to connect to {0}; is it up?
 gateway.connector.view.workspaces.connect.download-failed=Failed to download Coder CLI: {0}
-gateway.connector.view.workspaces.connect.failed=Failed to connect to {0}: {1}
+gateway.connector.view.workspaces.connect.ssl-error=Connection to {0} failed: {1}. See the \
+  <a href='https://coder.com/docs/v2/latest/ides/gateway#configuring-the-gateway-plugin-to-use-internal-certificates'>documentation for TLS certificates</a> \
+  for information on how to make your system trust certificates coming from your deployment.
 gateway.connector.view.workspaces.token.comment=The last used token is shown above.
 gateway.connector.view.workspaces.token.rejected=This token was rejected.
 gateway.connector.view.workspaces.token.injected=This token was pulled from your CLI config.


### PR DESCRIPTION
Since this help text contains markup which does not work in the table I added a new comment field underneath the URL input to place the error along with the help instead of trying to put it directly in the table.  I moved the other errors there too to be consistent and in the table it will tell you to look up for the details.

I also swapped `code-oss` for `v2` in two existing URLs since it seems that is the correct slug now.

![badssl](https://github.com/coder/jetbrains-coder/assets/45609798/a96158ed-94d2-47d6-a30f-3313e843d785)

Closes https://github.com/coder/jetbrains-coder/issues/251.