### PR TITLE
fix: remove version warning for 2.x releases

### DIFF
--- a/src/main/resources/version/CoderSupportedVersions.properties
+++ b/src/main/resources/version/CoderSupportedVersions.properties
@@ -1,2 +1,2 @@
-minCompatibleCoderVersion=0.12.9
-maxCompatibleCoderVersion=1.0.0
+minCompatibleCoderVersion=0.15.9
+maxCompatibleCoderVersion=3.0.0

--- a/src/main/resources/version/CoderSupportedVersions.properties
+++ b/src/main/resources/version/CoderSupportedVersions.properties
@@ -1,2 +1,2 @@
-minCompatibleCoderVersion=0.15.9
+minCompatibleCoderVersion=0.15.0
 maxCompatibleCoderVersion=3.0.0


### PR DESCRIPTION
We recently released a 2.0 which added a warning