### PR TITLE
Handle Gateway links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ To manually install a local build:
 
 Alternatively, `./gradlew clean runIde` will deploy a Gateway distribution (the one specified in `gradle.properties` - `platformVersion`) with the latest plugin changes deployed.
 
+To simulate opening a workspace from the dashboard pass the Gateway link via `--args`. For example:
+
+```
+./gradlew clean runIDE --args="jetbrains-gateway://connect#type=coder&workspace=dev&agent=coder&folder=/home/coder&url=https://dev.coder.com&token=<redacted>&ide_product_code=IU&ide_build_number=223.8836.41&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2022.3.3.tar.gz"
+```
+
+Alternatively, if you have separately built the plugin and already installed it
+in a Gateway distribution you can launch that distribution with the URL as the
+first argument (no `--args` in this case).
+
 ### Plugin Structure
 
 ```

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -2,16 +2,127 @@
 
 package com.coder.gateway
 
+import com.coder.gateway.models.TokenSource
+import com.coder.gateway.sdk.CoderCLIManager
+import com.coder.gateway.sdk.CoderRestClient
+import com.coder.gateway.sdk.ex.AuthenticationResponseException
+import com.coder.gateway.sdk.toURL
+import com.coder.gateway.sdk.v2.models.toAgentModels
+import com.coder.gateway.sdk.withPath
+import com.coder.gateway.services.CoderSettingsState
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.jetbrains.gateway.api.ConnectionRequestor
 import com.jetbrains.gateway.api.GatewayConnectionHandle
 import com.jetbrains.gateway.api.GatewayConnectionProvider
+import java.net.URL
 
+// In addition to `type`, these are the keys that we support in our Gateway
+// links.
+private const val URL = "url"
+private const val TOKEN = "token"
+private const val WORKSPACE = "workspace"
+private const val AGENT = "agent"
+private const val FOLDER = "folder"
+private const val IDE_DOWNLOAD_LINK = "ide_download_link"
+private const val IDE_PRODUCT_CODE = "ide_product_code"
+private const val IDE_BUILD_NUMBER = "ide_build_number"
+private const val IDE_PATH_ON_HOST = "ide_path_on_host"
+
+// CoderGatewayConnectionProvider handles connecting via a Gateway link such as
+// jetbrains-gateway://connect#type=coder.
 class CoderGatewayConnectionProvider : GatewayConnectionProvider {
+    private val settings: CoderSettingsState = service()
+
     override suspend fun connect(parameters: Map<String, String>, requestor: ConnectionRequestor): GatewayConnectionHandle? {
-        logger.debug("Launched Coder connection provider", parameters)
-        CoderRemoteConnectionHandle().connect(parameters)
+        CoderRemoteConnectionHandle().connect{ indicator ->
+            logger.debug("Launched Coder connection provider", parameters)
+
+            val deploymentURL = parameters[URL]
+                ?: CoderRemoteConnectionHandle.ask("Enter the full URL of your Coder deployment")
+            if (deploymentURL.isNullOrBlank()) {
+                throw IllegalArgumentException("Query parameter \"$URL\" is missing")
+            }
+
+            val (client, username) = authenticate(deploymentURL.toURL(), parameters[TOKEN])
+
+            // TODO: If these are missing we could launch the wizard.
+            val name = parameters[WORKSPACE] ?: throw IllegalArgumentException("Query parameter \"$WORKSPACE\" is missing")
+            val agent = parameters[AGENT] ?: throw IllegalArgumentException("Query parameter \"$AGENT\" is missing")
+
+            val workspaces = client.workspaces()
+            val agents = workspaces.flatMap { it.toAgentModels() }
+            val workspace = agents.firstOrNull { it.name == "$name.$agent" }
+                ?: throw IllegalArgumentException("The agent $agent does not exist on the workspace $name or the workspace is off")
+
+            // TODO: Turn on the workspace if it is off then wait for the agent
+            //       to be ready.  Also, distinguish between whether the
+            //       workspace is off or the agent does not exist in the error
+            //       above instead of showing a combined error.
+
+            val cli = CoderCLIManager.ensureCLI(
+                deploymentURL.toURL(),
+                client.buildInfo().version,
+                settings,
+                indicator,
+            )
+
+            indicator.text = "Authenticating Coder CLI..."
+            cli.login(client.token)
+
+            indicator.text = "Configuring Coder CLI..."
+            cli.configSsh(agents)
+
+            // TODO: Ask for these if missing.  Maybe we can reuse the second
+            //  step of the wizard?  Could also be nice if we automatically used
+            //  the last IDE.
+            if (parameters[IDE_PRODUCT_CODE].isNullOrBlank()) {
+                throw IllegalArgumentException("Query parameter \"$IDE_PRODUCT_CODE\" is missing")
+            }
+            if (parameters[IDE_BUILD_NUMBER].isNullOrBlank()) {
+                throw IllegalArgumentException("Query parameter \"$IDE_BUILD_NUMBER\" is missing")
+            }
+            if (parameters[IDE_PATH_ON_HOST].isNullOrBlank() && parameters[IDE_DOWNLOAD_LINK].isNullOrBlank()) {
+                throw IllegalArgumentException("One of \"$IDE_PATH_ON_HOST\" or \"$IDE_DOWNLOAD_LINK\" is required")
+            }
+
+            // TODO: Ask for the project path if missing and validate the path.
+            val folder = parameters[FOLDER] ?: throw IllegalArgumentException("Query parameter \"$FOLDER\" is missing")
+
+            parameters
+                .withWorkspaceHostname(CoderCLIManager.getHostName(deploymentURL.toURL(), workspace))
+                .withProjectPath(folder)
+                .withWebTerminalLink(client.url.withPath("/@$username/$workspace.name/terminal").toString())
+                .withConfigDirectory(cli.coderConfigPath.toString())
+                .withName(name)
+        }
         return null
+    }
+
+    /**
+     * Return an authenticated Coder CLI and the user's name, asking for the
+     * token as long as it continues to result in an authentication failure.
+     */
+    private fun authenticate(deploymentURL: URL, queryToken: String?, lastToken: Pair<String, TokenSource>? = null): Pair<CoderRestClient, String> {
+        // Use the token from the query, unless we already tried that.
+        val isRetry = lastToken != null
+        val token = if (!queryToken.isNullOrBlank() && !isRetry)
+            Pair(queryToken, TokenSource.QUERY)
+        else CoderRemoteConnectionHandle.askToken(
+            deploymentURL,
+            lastToken,
+            isRetry,
+            useExisting = true,
+        )
+        if (token == null) { // User aborted.
+            throw IllegalArgumentException("Unable to connect to $deploymentURL, $TOKEN is missing")
+        }
+        val client = CoderRestClient(deploymentURL, token.first)
+        return try {
+            Pair(client, client.me().username)
+        } catch (ex: AuthenticationResponseException) {
+            authenticate(deploymentURL, queryToken, token)
+        }
     }
 
     override fun isApplicable(parameters: Map<String, String>): Boolean {

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -2,90 +2,15 @@
 
 package com.coder.gateway
 
-import com.coder.gateway.sdk.humanizeDuration
-import com.coder.gateway.sdk.isCancellation
-import com.coder.gateway.sdk.isWorkerTimeout
-import com.coder.gateway.sdk.suspendingRetryWithExponentialBackOff
-import com.coder.gateway.services.CoderRecentWorkspaceConnectionsService
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.rd.util.launchUnderBackgroundProgress
-import com.intellij.openapi.ui.Messages
 import com.jetbrains.gateway.api.ConnectionRequestor
 import com.jetbrains.gateway.api.GatewayConnectionHandle
 import com.jetbrains.gateway.api.GatewayConnectionProvider
-import com.jetbrains.gateway.api.GatewayUI
-import com.jetbrains.gateway.ssh.SshDeployFlowUtil
-import com.jetbrains.gateway.ssh.SshMultistagePanelContext
-import com.jetbrains.gateway.ssh.deploy.DeployException
-import com.jetbrains.rd.util.lifetime.LifetimeDefinition
-import kotlinx.coroutines.launch
-import net.schmizz.sshj.common.SSHException
-import net.schmizz.sshj.connection.ConnectionException
-import java.time.Duration
-import java.util.concurrent.TimeoutException
 
 class CoderGatewayConnectionProvider : GatewayConnectionProvider {
-    private val recentConnectionsService = service<CoderRecentWorkspaceConnectionsService>()
-
     override suspend fun connect(parameters: Map<String, String>, requestor: ConnectionRequestor): GatewayConnectionHandle? {
-        val clientLifetime = LifetimeDefinition()
-        // TODO: If this fails determine if it is an auth error and if so prompt
-        // for a new token, configure the CLI, then try again.
-        clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title"), canBeCancelled = true, isIndeterminate = true, project = null) {
-            try {
-                indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting")
-                val context = suspendingRetryWithExponentialBackOff(
-                    action = { attempt ->
-                        logger.info("Connecting... (attempt $attempt")
-                        if (attempt > 1) {
-                            // indicator.text is the text above the progress bar.
-                            indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting.retry", attempt)
-                        }
-                        SshMultistagePanelContext(parameters.toHostDeployInputs())
-                    },
-                    retryIf = {
-                        it is ConnectionException || it is TimeoutException
-                                || it is SSHException || it is DeployException
-                    },
-                    onException = { attempt, nextMs, e ->
-                        logger.error("Failed to connect (attempt $attempt; will retry in $nextMs ms)")
-                        // indicator.text2 is the text below the progress bar.
-                        indicator.text2 =
-                            if (isWorkerTimeout(e)) "Failed to upload worker binary...it may have timed out"
-                            else e.message ?: CoderGatewayBundle.message("gateway.connector.no-details")
-                    },
-                    onCountdown = { remainingMs ->
-                        indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting.failed.retry", humanizeDuration(remainingMs))
-                    },
-                )
-                launch {
-                    logger.info("Deploying and starting IDE with $context")
-                    // At this point JetBrains takes over with their own UI.
-                    @Suppress("UnstableApiUsage") SshDeployFlowUtil.fullDeployCycle(
-                        clientLifetime, context, Duration.ofMinutes(10)
-                    )
-                }
-            } catch (e: Exception) {
-                if (isCancellation(e)) {
-                    logger.info("Connection canceled due to ${e.javaClass}")
-                } else {
-                    logger.info("Failed to connect (will not retry)", e)
-                    // The dialog will close once we return so write the error
-                    // out into a new dialog.
-                    ApplicationManager.getApplication().invokeAndWait {
-                        Messages.showMessageDialog(
-                            e.message ?: CoderGatewayBundle.message("gateway.connector.no-details"),
-                            CoderGatewayBundle.message("gateway.connector.coder.connection.failed"),
-                            Messages.getErrorIcon())
-                    }
-                }
-            }
-        }
-
-        recentConnectionsService.addRecentConnection(parameters.toRecentWorkspaceConnection())
-        GatewayUI.getInstance().reset()
+        logger.debug("Launched Coder connection provider", parameters)
+        CoderRemoteConnectionHandle().connect(parameters)
         return null
     }
 

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -116,7 +116,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
             }
 
             // Check that both the domain and the redirected domain are
-            // whitelisted.  If not, check with the user whether to proceed.
+            // allowlisted.  If not, check with the user whether to proceed.
             verifyDownloadLink(parameters, deploymentURL.toURL())
 
             // TODO: Ask for the project path if missing and validate the path.
@@ -159,7 +159,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
     }
 
     /**
-     * Check that the link is whitelisted.  If not, confirm with the user.
+     * Check that the link is allowlisted.  If not, confirm with the user.
      */
     private fun verifyDownloadLink(parameters: Map<String, String>, deploymentURL: URL) {
         val link = parameters[IDE_DOWNLOAD_LINK]
@@ -173,25 +173,25 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
             throw IllegalArgumentException("$link is not a valid URL")
         }
 
-        val (whitelisted, https, linkWithRedirect) = try {
-            CoderRemoteConnectionHandle.isWhitelisted(url, deploymentURL)
+        val (allowlisted, https, linkWithRedirect) = try {
+            CoderRemoteConnectionHandle.isAllowlisted(url, deploymentURL)
         } catch (e: Exception) {
             throw IllegalArgumentException("Unable to verify $url: $e")
         }
-        if (whitelisted && https) {
+        if (allowlisted && https) {
             return
         }
 
-        val comment = if (whitelisted) "The download link is from a non-whitelisted URL"
+        val comment = if (allowlisted) "The download link is from a non-allowlisted URL"
         else if (https) "The download link is not using HTTPS"
-        else "The download link is from a non-whitelisted URL and is not using HTTPS"
+        else "The download link is from a non-allowlisted URL and is not using HTTPS"
 
         if (!CoderRemoteConnectionHandle.confirm(
                 "Confirm download URL",
                 "$comment. Would you like to proceed?",
                 linkWithRedirect,
             )) {
-            throw IllegalArgumentException("$linkWithRedirect is not whitelisted")
+            throw IllegalArgumentException("$linkWithRedirect is not allowlisted")
         }
     }
 

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -117,7 +117,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
 
             // Check that both the domain and the redirected domain are
             // allowlisted.  If not, check with the user whether to proceed.
-            verifyDownloadLink(parameters, deploymentURL.toURL())
+            verifyDownloadLink(parameters)
 
             // TODO: Ask for the project path if missing and validate the path.
             val folder = parameters[FOLDER] ?: throw IllegalArgumentException("Query parameter \"$FOLDER\" is missing")
@@ -161,7 +161,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
     /**
      * Check that the link is allowlisted.  If not, confirm with the user.
      */
-    private fun verifyDownloadLink(parameters: Map<String, String>, deploymentURL: URL) {
+    private fun verifyDownloadLink(parameters: Map<String, String>) {
         val link = parameters[IDE_DOWNLOAD_LINK]
         if (link.isNullOrBlank()) {
             return // Nothing to verify
@@ -174,7 +174,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
         }
 
         val (allowlisted, https, linkWithRedirect) = try {
-            CoderRemoteConnectionHandle.isAllowlisted(url, deploymentURL)
+            CoderRemoteConnectionHandle.isAllowlisted(url)
         } catch (e: Exception) {
             throw IllegalArgumentException("Unable to verify $url: $e")
         }

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -68,7 +68,7 @@ class CoderRemoteConnectionHandle {
                         // indicator.text2 is the text below the progress bar.
                         indicator.text2 =
                             if (isWorkerTimeout(e)) "Failed to upload worker binary...it may have timed out"
-                            else e.message ?: CoderGatewayBundle.message("gateway.connector.no-details")
+                            else e.message ?: e.javaClass.simpleName
                     },
                     onCountdown = { remainingMs ->
                         indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting.failed.retry", humanizeDuration(remainingMs))
@@ -84,14 +84,14 @@ class CoderRemoteConnectionHandle {
                 recentConnectionsService.addRecentConnection(parameters.toRecentWorkspaceConnection())
             } catch (e: Exception) {
                 if (isCancellation(e)) {
-                    logger.info("Connection canceled due to ${e.javaClass}")
+                    logger.info("Connection canceled due to ${e.javaClass.simpleName}")
                 } else {
-                    logger.info("Failed to connect (will not retry)", e)
+                    logger.error("Failed to connect (will not retry)", e)
                     // The dialog will close once we return so write the error
                     // out into a new dialog.
                     ApplicationManager.getApplication().invokeAndWait {
                         Messages.showMessageDialog(
-                            e.message ?: CoderGatewayBundle.message("gateway.connector.no-details"),
+                            e.message ?: e.javaClass.simpleName,
                             CoderGatewayBundle.message("gateway.connector.coder.connection.failed"),
                             Messages.getErrorIcon())
                     }

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -107,7 +107,7 @@ class CoderRemoteConnectionHandle {
          * Generic function to ask for input.
          */
         @JvmStatic
-        fun ask(comment: String, isError: Boolean, link: Pair<String, String>?, default: String?): String? {
+        fun ask(comment: String, isError: Boolean = false, link: Pair<String, String>? = null, default: String? = null): String? {
             var inputFromUser: String? = null
             ApplicationManager.getApplication().invokeAndWait({
                 lateinit var inputTextField: JBTextField
@@ -169,7 +169,7 @@ class CoderRemoteConnectionHandle {
             } else if (!isRetry && useExisting) {
                 val (u, t) = CoderCLIManager.readConfig()
                 if (url == u?.toURL() && !t.isNullOrBlank() && t != existingToken) {
-                    logger.info("Injecting token from CLI config")
+                    logger.info("Injecting token for $url from CLI config")
                     tokenSource = TokenSource.CONFIG
                     existingToken = t
                 }
@@ -178,8 +178,10 @@ class CoderRemoteConnectionHandle {
                 CoderGatewayBundle.message(
                     if (isRetry) "gateway.connector.view.workspaces.token.rejected"
                     else if (tokenSource == TokenSource.CONFIG) "gateway.connector.view.workspaces.token.injected"
+                    else if (tokenSource == TokenSource.QUERY) "gateway.connector.view.workspaces.token.query"
                     else if (existingToken.isNotBlank()) "gateway.connector.view.workspaces.token.comment"
-                    else "gateway.connector.view.workspaces.token.none"
+                    else "gateway.connector.view.workspaces.token.none",
+                    url.host,
                 ),
                 isRetry,
                 Pair(

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -244,10 +244,10 @@ class CoderRemoteConnectionHandle {
          * destination, if it is a different host.
          */
         @JvmStatic
-        fun isAllowlisted(url: URL, deploymentURL: URL): Triple<Boolean, Boolean, String> {
+        fun isAllowlisted(url: URL): Triple<Boolean, Boolean, String> {
             // TODO: Setting for the allowlist, and remember previously allowed
             //  domains.
-            val domainAllowlist = listOf("intellij.net", "jetbrains.com", deploymentURL.host)
+            val domainAllowlist = listOf("intellij.net", "jetbrains.com")
 
             // Resolve any redirects.
             val finalUrl = try {

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -240,14 +240,14 @@ class CoderRemoteConnectionHandle {
         }
 
         /**
-         * Return if the URL is whitelisted, https, and the URL and its final
+         * Return if the URL is allowlisted, https, and the URL and its final
          * destination, if it is a different host.
          */
         @JvmStatic
-        fun isWhitelisted(url: URL, deploymentURL: URL): Triple<Boolean, Boolean, String> {
-            // TODO: Setting for the whitelist, and remember previously allowed
+        fun isAllowlisted(url: URL, deploymentURL: URL): Triple<Boolean, Boolean, String> {
+            // TODO: Setting for the allowlist, and remember previously allowed
             //  domains.
-            val domainWhitelist = listOf("intellij.net", "jetbrains.com", deploymentURL.host)
+            val domainAllowlist = listOf("intellij.net", "jetbrains.com", deploymentURL.host)
 
             // Resolve any redirects.
             val finalUrl = try {
@@ -269,10 +269,10 @@ class CoderRemoteConnectionHandle {
                 linkWithRedirect = "$linkWithRedirect (redirects to to $finalUrl)"
             }
 
-            val whitelisted = domainWhitelist.any { url.host == it || url.host.endsWith(".$it") }
-                    && domainWhitelist.any { finalUrl.host == it || finalUrl.host.endsWith(".$it") }
+            val allowlisted = domainAllowlist.any { url.host == it || url.host.endsWith(".$it") }
+                    && domainAllowlist.any { finalUrl.host == it || finalUrl.host.endsWith(".$it") }
             val https = url.protocol == "https" && finalUrl.protocol == "https"
-            return Triple(whitelisted, https, linkWithRedirect)
+            return Triple(allowlisted, https, linkWithRedirect)
         }
 
         /**

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.rd.util.launchUnderBackgroundProgress
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.panel.ComponentPanelBuilder
@@ -44,11 +45,12 @@ import java.util.concurrent.TimeoutException
 class CoderRemoteConnectionHandle {
     private val recentConnectionsService = service<CoderRecentWorkspaceConnectionsService>()
 
-    suspend fun connect(parameters: Map<String, String>) {
-        logger.debug("Creating connection handle", parameters)
+    suspend fun connect(getParameters: (indicator: ProgressIndicator) -> Map<String, String>) {
         val clientLifetime = LifetimeDefinition()
         clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title"), canBeCancelled = true, isIndeterminate = true, project = null) {
             try {
+                val parameters = getParameters(indicator)
+                logger.debug("Creating connection handle", parameters)
                 indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting")
                 val context = suspendingRetryWithExponentialBackOff(
                     action = { attempt ->

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -1,0 +1,92 @@
+@file:Suppress("DialogTitleCapitalization")
+
+package com.coder.gateway
+
+import com.coder.gateway.sdk.humanizeDuration
+import com.coder.gateway.sdk.isCancellation
+import com.coder.gateway.sdk.isWorkerTimeout
+import com.coder.gateway.sdk.suspendingRetryWithExponentialBackOff
+import com.coder.gateway.services.CoderRecentWorkspaceConnectionsService
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.rd.util.launchUnderBackgroundProgress
+import com.intellij.openapi.ui.Messages
+import com.jetbrains.gateway.ssh.SshDeployFlowUtil
+import com.jetbrains.gateway.ssh.SshMultistagePanelContext
+import com.jetbrains.gateway.ssh.deploy.DeployException
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlinx.coroutines.launch
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.connection.ConnectionException
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+
+// CoderRemoteConnection uses the provided workspace SSH parameters to launch an
+// IDE against the workspace.  If successful the connection is added to recent
+// connections.
+class CoderRemoteConnectionHandle {
+    private val recentConnectionsService = service<CoderRecentWorkspaceConnectionsService>()
+
+    suspend fun connect(parameters: Map<String, String>) {
+        logger.debug("Creating connection handle", parameters)
+        val clientLifetime = LifetimeDefinition()
+        // TODO: If this fails determine if it is an auth error and if so prompt
+        // for a new token, configure the CLI, then try again.
+        clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title"), canBeCancelled = true, isIndeterminate = true, project = null) {
+            try {
+                indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting")
+                val context = suspendingRetryWithExponentialBackOff(
+                    action = { attempt ->
+                        logger.info("Connecting... (attempt $attempt")
+                        if (attempt > 1) {
+                            // indicator.text is the text above the progress bar.
+                            indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting.retry", attempt)
+                        }
+                        SshMultistagePanelContext(parameters.toHostDeployInputs())
+                    },
+                    retryIf = {
+                        it is ConnectionException || it is TimeoutException
+                                || it is SSHException || it is DeployException
+                    },
+                    onException = { attempt, nextMs, e ->
+                        logger.error("Failed to connect (attempt $attempt; will retry in $nextMs ms)")
+                        // indicator.text2 is the text below the progress bar.
+                        indicator.text2 =
+                            if (isWorkerTimeout(e)) "Failed to upload worker binary...it may have timed out"
+                            else e.message ?: CoderGatewayBundle.message("gateway.connector.no-details")
+                    },
+                    onCountdown = { remainingMs ->
+                        indicator.text = CoderGatewayBundle.message("gateway.connector.coder.connecting.failed.retry", humanizeDuration(remainingMs))
+                    },
+                )
+                launch {
+                    logger.info("Deploying and starting IDE with $context")
+                    // At this point JetBrains takes over with their own UI.
+                    @Suppress("UnstableApiUsage") SshDeployFlowUtil.fullDeployCycle(
+                        clientLifetime, context, Duration.ofMinutes(10)
+                    )
+                }
+                recentConnectionsService.addRecentConnection(parameters.toRecentWorkspaceConnection())
+            } catch (e: Exception) {
+                if (isCancellation(e)) {
+                    logger.info("Connection canceled due to ${e.javaClass}")
+                } else {
+                    logger.info("Failed to connect (will not retry)", e)
+                    // The dialog will close once we return so write the error
+                    // out into a new dialog.
+                    ApplicationManager.getApplication().invokeAndWait {
+                        Messages.showMessageDialog(
+                            e.message ?: CoderGatewayBundle.message("gateway.connector.no-details"),
+                            CoderGatewayBundle.message("gateway.connector.coder.connection.failed"),
+                            Messages.getErrorIcon())
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val logger = Logger.getInstance(CoderRemoteConnectionHandle::class.java.simpleName)
+    }
+}

--- a/src/main/kotlin/com/coder/gateway/WorkspaceParams.kt
+++ b/src/main/kotlin/com/coder/gateway/WorkspaceParams.kt
@@ -98,7 +98,7 @@ fun Map<String, String>.withName(name: String): Map<String, String> {
 
 
 fun Map<String, String>.areCoderType(): Boolean {
-    return this[TYPE] == VALUE_FOR_TYPE && !this[CODER_WORKSPACE_HOSTNAME].isNullOrBlank() && !this[PROJECT_PATH].isNullOrBlank()
+    return this[TYPE] == VALUE_FOR_TYPE
 }
 
 fun Map<String, String>.toSshConfig(): SshConfig {

--- a/src/main/kotlin/com/coder/gateway/models/CoderWorkspacesWizardModel.kt
+++ b/src/main/kotlin/com/coder/gateway/models/CoderWorkspacesWizardModel.kt
@@ -3,6 +3,7 @@ package com.coder.gateway.models
 enum class TokenSource {
     CONFIG,    // Pulled from the Coder CLI config.
     USER,      // Input by the user.
+    QUERY,     // From the Gateway link as a query parameter.
     LAST_USED, // Last used token, either from storage or current run.
 }
 

--- a/src/main/kotlin/com/coder/gateway/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/gateway/models/WorkspaceAndAgentStatus.kt
@@ -57,6 +57,14 @@ enum class WorkspaceAndAgentStatus(val icon: Icon, val label: String, val descri
             .contains(this)
     }
 
+    /**
+     * Return true if the agent might soon be in a connectable state.
+     */
+    fun pending(): Boolean {
+        return listOf(CONNECTING, TIMEOUT, CREATED, AGENT_STARTING, START_TIMEOUT)
+            .contains(this)
+    }
+
     // We want to check that the workspace is `running`, the agent is
     // `connected`, and the agent lifecycle state is `ready` to ensure the best
     // possible scenario for attempting a connection.

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderRestClientService.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderRestClientService.kt
@@ -50,7 +50,7 @@ class CoderRestClientService {
     }
 }
 
-class CoderRestClient(var url: URL, private var token: String) {
+class CoderRestClient(var url: URL, var token: String) {
     private var httpClient: OkHttpClient
     private var retroRestClient: CoderV2RestFacade
 
@@ -75,7 +75,7 @@ class CoderRestClient(var url: URL, private var token: String) {
     fun me(): User {
         val userResponse = retroRestClient.me().execute()
         if (!userResponse.isSuccessful) {
-            throw AuthenticationResponseException("Could not retrieve information about logged user:${userResponse.code()}, reason: ${userResponse.message().ifBlank { "no reason provided" }}")
+            throw AuthenticationResponseException("Authentication to $url failed with code ${userResponse.code()}, ${userResponse.message().ifBlank { "has your token expired?" }}")
         }
 
         return userResponse.body()!!
@@ -88,7 +88,7 @@ class CoderRestClient(var url: URL, private var token: String) {
     fun workspaces(): List<Workspace> {
         val workspacesResponse = retroRestClient.workspaces("owner:me").execute()
         if (!workspacesResponse.isSuccessful) {
-            throw WorkspaceResponseException("Could not retrieve Coder Workspaces:${workspacesResponse.code()}, reason: ${workspacesResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Retrieving workspaces from $url failed with code ${workspacesResponse.code()}, reason: ${workspacesResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return workspacesResponse.body()!!.workspaces
@@ -97,15 +97,15 @@ class CoderRestClient(var url: URL, private var token: String) {
     fun buildInfo(): BuildInfo {
         val buildInfoResponse = retroRestClient.buildInfo().execute()
         if (!buildInfoResponse.isSuccessful) {
-            throw java.lang.IllegalStateException("Could not retrieve build information for Coder instance $url, reason:${buildInfoResponse.message().ifBlank { "no reason provided" }}")
+            throw java.lang.IllegalStateException("Retrieving build information for $url failed with code ${buildInfoResponse.code()}, reason:${buildInfoResponse.message().ifBlank { "no reason provided" }}")
         }
         return buildInfoResponse.body()!!
     }
 
-    fun template(templateID: UUID): Template {
+    private fun template(templateID: UUID): Template {
         val templateResponse = retroRestClient.template(templateID).execute()
         if (!templateResponse.isSuccessful) {
-            throw TemplateResponseException("Failed to retrieve template with id: $templateID, reason: ${templateResponse.message().ifBlank { "no reason provided" }}")
+            throw TemplateResponseException("Retrieving template with id $templateID from $url failed with code ${templateResponse.code()}, reason: ${templateResponse.message().ifBlank { "no reason provided" }}")
         }
         return templateResponse.body()!!
     }
@@ -114,7 +114,7 @@ class CoderRestClient(var url: URL, private var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.START, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Failed to build workspace ${workspaceName}: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Building workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!
@@ -124,7 +124,7 @@ class CoderRestClient(var url: URL, private var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.STOP, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Failed to stop workspace ${workspaceName}: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Stopping workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!
@@ -136,7 +136,7 @@ class CoderRestClient(var url: URL, private var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(template.activeVersionID, lastWorkspaceTransition, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Failed to update workspace ${workspaceName}: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Updating workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderRestClientService.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderRestClientService.kt
@@ -75,7 +75,7 @@ class CoderRestClient(var url: URL, var token: String) {
     fun me(): User {
         val userResponse = retroRestClient.me().execute()
         if (!userResponse.isSuccessful) {
-            throw AuthenticationResponseException("Authentication to $url failed with code ${userResponse.code()}, ${userResponse.message().ifBlank { "has your token expired?" }}")
+            throw AuthenticationResponseException("Unable to authenticate to $url: code ${userResponse.code()}, ${userResponse.message().ifBlank { "has your token expired?" }}")
         }
 
         return userResponse.body()!!
@@ -88,7 +88,7 @@ class CoderRestClient(var url: URL, var token: String) {
     fun workspaces(): List<Workspace> {
         val workspacesResponse = retroRestClient.workspaces("owner:me").execute()
         if (!workspacesResponse.isSuccessful) {
-            throw WorkspaceResponseException("Retrieving workspaces from $url failed with code ${workspacesResponse.code()}, reason: ${workspacesResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Unable to retrieve workspaces from $url: code ${workspacesResponse.code()}, reason: ${workspacesResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return workspacesResponse.body()!!.workspaces
@@ -97,7 +97,7 @@ class CoderRestClient(var url: URL, var token: String) {
     fun buildInfo(): BuildInfo {
         val buildInfoResponse = retroRestClient.buildInfo().execute()
         if (!buildInfoResponse.isSuccessful) {
-            throw java.lang.IllegalStateException("Retrieving build information for $url failed with code ${buildInfoResponse.code()}, reason:${buildInfoResponse.message().ifBlank { "no reason provided" }}")
+            throw java.lang.IllegalStateException("Unable to retrieve build information for $url, code: ${buildInfoResponse.code()}, reason: ${buildInfoResponse.message().ifBlank { "no reason provided" }}")
         }
         return buildInfoResponse.body()!!
     }
@@ -105,7 +105,7 @@ class CoderRestClient(var url: URL, var token: String) {
     private fun template(templateID: UUID): Template {
         val templateResponse = retroRestClient.template(templateID).execute()
         if (!templateResponse.isSuccessful) {
-            throw TemplateResponseException("Retrieving template with id $templateID from $url failed with code ${templateResponse.code()}, reason: ${templateResponse.message().ifBlank { "no reason provided" }}")
+            throw TemplateResponseException("Unable to retrieve template with ID $templateID from $url, code: ${templateResponse.code()}, reason: ${templateResponse.message().ifBlank { "no reason provided" }}")
         }
         return templateResponse.body()!!
     }
@@ -114,7 +114,7 @@ class CoderRestClient(var url: URL, var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.START, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Building workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Unable to build workspace $workspaceName on $url, code: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!
@@ -124,7 +124,7 @@ class CoderRestClient(var url: URL, var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.STOP, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Stopping workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Unable to stop workspace $workspaceName on $url, code: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!
@@ -136,7 +136,7 @@ class CoderRestClient(var url: URL, var token: String) {
         val buildRequest = CreateWorkspaceBuildRequest(template.activeVersionID, lastWorkspaceTransition, null, null, null, null)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspaceID, buildRequest).execute()
         if (buildResponse.code() != HTTP_CREATED) {
-            throw WorkspaceResponseException("Updating workspace $workspaceName on $url failed with code ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
+            throw WorkspaceResponseException("Unable to update workspace $workspaceName on $url, code: ${buildResponse.code()}, reason: ${buildResponse.message().ifBlank { "no reason provided" }}")
         }
 
         return buildResponse.body()!!

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -4,6 +4,7 @@ package com.coder.gateway.views
 
 import com.coder.gateway.CoderGatewayBundle
 import com.coder.gateway.CoderGatewayConstants
+import com.coder.gateway.CoderRemoteConnectionHandle
 import com.coder.gateway.icons.CoderIcons
 import com.coder.gateway.models.RecentWorkspaceConnection
 import com.coder.gateway.models.WorkspaceAgentModel
@@ -215,7 +216,8 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                         icon(product.icon)
                         cell(ActionLink(connectionDetails.projectPath!!) {
                             cs.launch {
-                                GatewayUI.getInstance().connect(connectionDetails.toWorkspaceParams())
+                                CoderRemoteConnectionHandle().connect(connectionDetails.toWorkspaceParams())
+                                GatewayUI.getInstance().reset()
                             }
                         })
                         label("").resizableColumn().align(AlignX.FILL)

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -216,7 +216,7 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                         icon(product.icon)
                         cell(ActionLink(connectionDetails.projectPath!!) {
                             cs.launch {
-                                CoderRemoteConnectionHandle().connect(connectionDetails.toWorkspaceParams())
+                                CoderRemoteConnectionHandle().connect{ connectionDetails.toWorkspaceParams() }
                                 GatewayUI.getInstance().reset()
                             }
                         })

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
@@ -1,6 +1,7 @@
 package com.coder.gateway.views.steps
 
 import com.coder.gateway.CoderGatewayBundle
+import com.coder.gateway.CoderRemoteConnectionHandle
 import com.coder.gateway.icons.CoderIcons
 import com.coder.gateway.models.CoderWorkspacesWizardModel
 import com.coder.gateway.models.WorkspaceAgentModel
@@ -338,7 +339,7 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
             return false
         }
         cs.launch {
-            GatewayUI.getInstance().connect(
+            CoderRemoteConnectionHandle().connect(
                 selectedIDE
                     .toWorkspaceParams()
                     .withWorkspaceHostname(CoderCLIManager.getHostName(deploymentURL, selectedWorkspace))
@@ -347,6 +348,7 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
                     .withConfigDirectory(wizardModel.configDirectory)
                     .withName(selectedWorkspace.name)
             )
+            GatewayUI.getInstance().reset()
         }
         return true
     }

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
@@ -213,7 +213,7 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
                         cbIDEComment.foreground = UIUtil.getErrorForeground()
                         cbIDEComment.text =
                             if (isWorkerTimeout(e)) "Failed to upload worker binary...it may have timed out.  Check the command log for more details."
-                            else e.message ?: CoderGatewayBundle.message("gateway.connector.no-details")
+                            else e.message ?: e.javaClass.simpleName
                     },
                     onCountdown = { remainingMs ->
                         cbIDE.renderer = IDECellRenderer(CoderGatewayBundle.message("gateway.connector.view.coder.retrieve-ides.failed.retry", humanizeDuration(remainingMs)))
@@ -225,11 +225,11 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
                 }
             } catch (e: Exception) {
                 if (isCancellation(e)) {
-                    logger.info("Connection canceled due to ${e.javaClass}")
+                    logger.info("Connection canceled due to ${e.javaClass.simpleName}")
                 } else {
                     logger.error("Failed to retrieve IDEs (will not retry)", e)
                     cbIDEComment.foreground = UIUtil.getErrorForeground()
-                    cbIDEComment.text = e.message ?: CoderGatewayBundle.message("gateway.connector.no-details")
+                    cbIDEComment.text = e.message ?: e.javaClass.simpleName
                     cbIDE.renderer = IDECellRenderer(CoderGatewayBundle.message("gateway.connector.view.coder.retrieve-ides.failed"), UIUtil.getBalloonErrorIcon())
                 }
             }

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderLocateRemoteProjectStepView.kt
@@ -339,7 +339,7 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
             return false
         }
         cs.launch {
-            CoderRemoteConnectionHandle().connect(
+            CoderRemoteConnectionHandle().connect{
                 selectedIDE
                     .toWorkspaceParams()
                     .withWorkspaceHostname(CoderCLIManager.getHostName(deploymentURL, selectedWorkspace))
@@ -347,7 +347,7 @@ class CoderLocateRemoteProjectStepView(private val setNextButtonEnabled: (Boolea
                     .withWebTerminalLink("${terminalLink.url}")
                     .withConfigDirectory(wizardModel.configDirectory)
                     .withName(selectedWorkspace.name)
-            )
+            }
             GatewayUI.getInstance().reset()
         }
         return true

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -36,10 +36,11 @@ gateway.connector.view.workspaces.connect.download-failed=Failed to download Cod
 gateway.connector.view.workspaces.connect.ssl-error=Connection to {0} failed: {1}. See the \
   <a href='https://coder.com/docs/v2/latest/ides/gateway#configuring-the-gateway-plugin-to-use-internal-certificates'>documentation for TLS certificates</a> \
   for information on how to make your system trust certificates coming from your deployment.
-gateway.connector.view.workspaces.token.comment=The last used token is shown above.
-gateway.connector.view.workspaces.token.rejected=This token was rejected.
-gateway.connector.view.workspaces.token.injected=This token was pulled from your CLI config.
-gateway.connector.view.workspaces.token.none=No existing token found.
+gateway.connector.view.workspaces.token.comment=The last used token for {0} is shown above.
+gateway.connector.view.workspaces.token.rejected=This token was rejected by {0}.
+gateway.connector.view.workspaces.token.injected=This token was pulled from your CLI config for {0}.
+gateway.connector.view.workspaces.token.query=This token was pulled from the Gateway link from {0}.
+gateway.connector.view.workspaces.token.none=No existing token for {0} found.
 gateway.connector.view.coder.connect-ssh=Establishing SSH connection to remote worker...
 gateway.connector.view.coder.connect-ssh.retry=Establishing SSH connection to remote worker (attempt {0})...
 gateway.connector.view.coder.retrieve-ides=Retrieving IDEs...

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -70,7 +70,7 @@ gateway.connector.settings.data-directory.comment=Directories are created \
   Defaults to {0}.
 gateway.connector.settings.binary-source.title=CLI source:
 gateway.connector.settings.binary-source.comment=Used to download the Coder \
-  CLI which is necessary to make SSH connections. The If-None-Matched header \
+  CLI which is necessary to make SSH connections. The If-None-Match header \
   will be set to the SHA1 of the CLI and can be used for caching. Absolute \
   URLs will be used as-is; otherwise this value will be resolved against the \
   deployment domain. \

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -87,4 +87,3 @@ gateway.connector.settings.enable-binary-directory-fallback.title=Fall back to d
 gateway.connector.settings.enable-binary-directory-fallback.comment=Checking this \
   box will allow the plugin to fall back to the data directory when the CLI \
   directory is not writable.
-gateway.connector.no-details="The error did not provide any further details"

--- a/src/test/groovy/CoderRemoteConnectionHandleTest.groovy
+++ b/src/test/groovy/CoderRemoteConnectionHandleTest.groovy
@@ -1,0 +1,72 @@
+package com.coder.gateway
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class CoderRemoteConnectionHandleTest extends Specification {
+    /**
+     * Create, start, and return a server that uses the provided handler.
+     */
+    def mockServer(HttpHandler handler) {
+        HttpServer srv = HttpServer.create(new InetSocketAddress(0), 0)
+        srv.createContext("/", handler)
+        srv.start()
+        return [srv, "http://localhost:" + srv.address.port]
+    }
+
+    /**
+     * Create, start, and return a server that mocks redirects.
+     */
+    def mockRedirectServer(String location, Boolean temp) {
+        return mockServer(new HttpHandler() {
+            void handle(HttpExchange exchange) {
+                exchange.responseHeaders.set("Location", location)
+                exchange.sendResponseHeaders(
+                        temp ? HttpURLConnection.HTTP_MOVED_TEMP : HttpURLConnection.HTTP_MOVED_PERM,
+                        -1)
+                exchange.close()
+            }
+        })
+    }
+
+    def "follows redirects"() {
+        given:
+        def (srv1, url1) = mockServer(new HttpHandler() {
+            void handle(HttpExchange exchange) {
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, -1)
+                exchange.close()
+            }
+        })
+        def (srv2, url2) = mockRedirectServer(url1, false)
+        def (srv3, url3) = mockRedirectServer(url2, true)
+
+        when:
+        def resolved = CoderRemoteConnectionHandle.resolveRedirects(new URL(url3))
+
+        then:
+        resolved.toString() == url1
+
+        cleanup:
+        srv1.stop(0)
+        srv2.stop(0)
+        srv3.stop(0)
+    }
+
+    def "follows maximum redirects"() {
+        given:
+        def (srv, url) = mockRedirectServer(".", true)
+
+        when:
+        CoderRemoteConnectionHandle.resolveRedirects(new URL(url))
+
+        then:
+        thrown(Exception)
+
+        cleanup:
+        srv.stop(0)
+    }
+}


### PR DESCRIPTION
I created a new class to share some common connection code between the step-based wizard flow and the link-based flow.  I think we can share more things as we go on but I did not try too hard to combine more code until the shape of the link-based flow solidifies some more.  So there is some duplication like the authentication loop, logging in the CLI, etc, that cannot be easily shared without some refactoring.

It might even end up being that we just always launch into the wizard flow but if some parameters are already set we automatically skip through certain steps.  Not sure.

This is a first pass, right now you have to specify most of the parameters yourself (aside from deployment URL and token which, if missing, will trigger prompts to the user).

There are a few todos that I want to take in subsequent PRs to make the experience better, like making sure the workspace is on (and turning it on if needed) and giving the ability to select the IDE you want if one was not specified (or perhaps defaulting to the last used one).

The flow can be triggered with a URL like this: 

```
jetbrains-gateway://connect#type=coder&workspace=dev&agent=coder&folder=/home/coder&url=https://oss.demo.coder.com&token=<redacted>&ide_product_code=IU&ide_build_number=223.8836.41&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2022.3.3.tar.gz
```

For example, this should work if you run `gateway.sh <url>`.  But this build of the plugin will need to be already installed since otherwise it will automatically install the currently published version which does not support the link yet.

Or, if running Gateway from the `runIDE` task (which will build and provide the plugin automatically), pass the URL via `--args`.

Or, something like `xdg-open <url>` (on Linux) might work too.

Or, adding it as an external link to a template.

More details in the commit messages, and they can be reviewed separately.

Closes https://github.com/coder/jetbrains-coder/issues/149.