### PR TITLE
Fix missing agents when workspaces are off

### DIFF
--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -3,10 +3,12 @@
 package com.coder.gateway
 
 import com.coder.gateway.models.TokenSource
+import com.coder.gateway.models.WorkspaceAgentModel
 import com.coder.gateway.sdk.CoderCLIManager
 import com.coder.gateway.sdk.CoderRestClient
 import com.coder.gateway.sdk.ex.AuthenticationResponseException
 import com.coder.gateway.sdk.toURL
+import com.coder.gateway.sdk.v2.models.Workspace
 import com.coder.gateway.sdk.v2.models.WorkspaceStatus
 import com.coder.gateway.sdk.v2.models.toAgentModels
 import com.coder.gateway.sdk.withPath
@@ -67,30 +69,8 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
                 WorkspaceStatus.RUNNING -> Unit // All is well
             }
 
-            val agents = workspace.toAgentModels()
-            if (agents.isEmpty()) {
-                throw IllegalArgumentException("The workspace \"$workspaceName\" has no agents")
-            }
-
-            // If the agent is missing and the workspace has only one, use that.
-            // Prefer the ID over the name if both are set.
-            val agent = if (!parameters[AGENT_ID].isNullOrBlank())
-                agents.firstOrNull {it.agentID.toString() == parameters[AGENT_ID]}
-            else if (!parameters[AGENT_NAME].isNullOrBlank())
-                agents.firstOrNull { it.name == "$workspaceName.${parameters[AGENT_NAME]}"}
-            else if (agents.size == 1) agents.first()
-            else null
-
-            if (agent == null) {
-                if (parameters[AGENT_ID].isNullOrBlank() && parameters[AGENT_NAME].isNullOrBlank()) {
-                    // TODO: Show a dropdown and ask for an agent.
-                    throw IllegalArgumentException("Unable to determine which agent to connect to; one of \"$AGENT_NAME\" or \"$AGENT_ID\" must be set because \"$workspaceName\" has more than one agent")
-                } else if (parameters[AGENT_ID].isNullOrBlank()) {
-                    throw IllegalArgumentException("The workspace \"$workspaceName\" does not have an agent with ID \"${parameters[AGENT_ID]}\"")
-                } else {
-                    throw IllegalArgumentException("The workspace \"$workspaceName\" does not have an agent named \"${parameters[AGENT_NAME]}\"")
-                }
-            }
+            // TODO: Show a dropdown and ask for an agent if missing.
+            val agent = getMatchingAgent(parameters, workspace)
 
             if (agent.agentStatus.pending()) {
                 // TODO: Wait for the agent to be ready.
@@ -211,5 +191,49 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
 
     companion object {
         val logger = Logger.getInstance(CoderGatewayConnectionProvider::class.java.simpleName)
+
+        /**
+         * Return the agent matching the provided agent ID or name in the
+         * parameters.  The name is ignored if the ID is set.  If neither was
+         * supplied and the workspace has only one agent, return that.
+         * Otherwise throw an error.
+         *
+         * @throws [MissingArgumentException, IllegalArgumentException]
+         */
+        @JvmStatic
+        fun getMatchingAgent(parameters: Map<String, String>, workspace: Workspace): WorkspaceAgentModel {
+            // A WorkspaceAgentModel will still be returned if there are no
+            // agents; in this case it represents the workspace instead.
+            // TODO: Seems confusing for something with "agent" in the name to
+            //       potentially not actually be an agent; can we replace
+            //       WorkspaceAgentModel with the original structs from the API?
+            val agents = workspace.toAgentModels()
+            if (agents.isEmpty() || (agents.size == 1 && agents.first().agentID == null)) {
+                throw IllegalArgumentException("The workspace \"${workspace.name}\" has no agents")
+            }
+
+            // If the agent is missing and the workspace has only one, use that.
+            // Prefer the ID over the name if both are set.
+            val agent = if (!parameters[AGENT_ID].isNullOrBlank())
+                agents.firstOrNull { it.agentID.toString() == parameters[AGENT_ID] }
+            else if (!parameters[AGENT_NAME].isNullOrBlank())
+                agents.firstOrNull { it.name == "${workspace.name}.${parameters[AGENT_NAME]}"}
+            else if (agents.size == 1) agents.first()
+            else null
+
+            if (agent == null) {
+                if (!parameters[AGENT_ID].isNullOrBlank()) {
+                    throw IllegalArgumentException("The workspace \"${workspace.name}\" does not have an agent with ID \"${parameters[AGENT_ID]}\"")
+                } else if (!parameters[AGENT_NAME].isNullOrBlank()){
+                    throw IllegalArgumentException("The workspace \"${workspace.name}\"does not have an agent named \"${parameters[AGENT_NAME]}\"")
+                } else {
+                    throw MissingArgumentException("Unable to determine which agent to connect to; one of \"$AGENT_NAME\" or \"$AGENT_ID\" must be set because the workspace \"${workspace.name}\" has more than one agent")
+                }
+            }
+
+            return agent
+        }
     }
 }
+
+class MissingArgumentException(message: String) : IllegalArgumentException(message)

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -140,7 +140,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
         if (token == null) { // User aborted.
             throw IllegalArgumentException("Unable to connect to $deploymentURL, $TOKEN is missing")
         }
-        val client = CoderRestClient(deploymentURL, token.first, settings.headerCommand)
+        val client = CoderRestClient(deploymentURL, token.first, settings.headerCommand, null)
         return try {
             Pair(client, client.me().username)
         } catch (ex: AuthenticationResponseException) {

--- a/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderGatewayConnectionProvider.kt
@@ -100,7 +100,7 @@ class CoderGatewayConnectionProvider : GatewayConnectionProvider {
             cli.login(client.token)
 
             indicator.text = "Configuring Coder CLI..."
-            cli.configSsh(workspaces.flatMap { it.toAgentModels() }, settings.headerCommand)
+            cli.configSsh(client.agents(workspaces), settings.headerCommand)
 
             // TODO: Ask for these if missing.  Maybe we can reuse the second
             //  step of the wizard?  Could also be nice if we automatically used

--- a/src/main/kotlin/com/coder/gateway/models/WorkspaceAgentModel.kt
+++ b/src/main/kotlin/com/coder/gateway/models/WorkspaceAgentModel.kt
@@ -17,7 +17,7 @@ data class WorkspaceAgentModel(
     val agentID: UUID?,
     val workspaceID: UUID,
     val workspaceName: String,
-    val name: String, // Name of the workspace OR the agent if this is for an agent.
+    val name: String, // Name of the workspace OR workspace.agent if this is for an agent.
     val templateID: UUID,
     val templateName: String,
     val templateIconPath: String,

--- a/src/main/kotlin/com/coder/gateway/models/WorkspaceAgentModel.kt
+++ b/src/main/kotlin/com/coder/gateway/models/WorkspaceAgentModel.kt
@@ -14,6 +14,7 @@ import javax.swing.Icon
 // iterate over the list we can add the workspace row if it has no agents
 // otherwise iterate over the agents and then flatten the result.
 data class WorkspaceAgentModel(
+    val agentID: UUID?,
     val workspaceID: UUID,
     val workspaceName: String,
     val name: String, // Name of the workspace OR the agent if this is for an agent.

--- a/src/main/kotlin/com/coder/gateway/sdk/v2/CoderV2RestFacade.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/CoderV2RestFacade.kt
@@ -5,6 +5,7 @@ import com.coder.gateway.sdk.v2.models.CreateWorkspaceBuildRequest
 import com.coder.gateway.sdk.v2.models.Template
 import com.coder.gateway.sdk.v2.models.User
 import com.coder.gateway.sdk.v2.models.WorkspaceBuild
+import com.coder.gateway.sdk.v2.models.WorkspaceResource
 import com.coder.gateway.sdk.v2.models.WorkspacesResponse
 import retrofit2.Call
 import retrofit2.http.Body
@@ -39,4 +40,7 @@ interface CoderV2RestFacade {
 
     @GET("api/v2/templates/{templateID}")
     fun template(@Path("templateID") templateID: UUID): Call<Template>
+
+    @GET("api/v2/templateversions/{templateID}/resources")
+    fun templateVersionResources(@Path("templateID") templateID: UUID): Call<List<WorkspaceResource>>
 }

--- a/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
@@ -35,6 +35,7 @@ fun Workspace.toAgentModels(resources: List<WorkspaceResource> = this.latestBuil
     val wam = resources.filter { it.agents != null }.flatMap { it.agents!! }.map { agent ->
         val workspaceWithAgentName = "${this.name}.${agent.name}"
         val wm = WorkspaceAgentModel(
+            agent.id,
             this.id,
             this.name,
             workspaceWithAgentName,
@@ -55,6 +56,7 @@ fun Workspace.toAgentModels(resources: List<WorkspaceResource> = this.latestBuil
     }.toSet()
     if (wam.isNullOrEmpty()) {
         val wm = WorkspaceAgentModel(
+            null,
             this.id,
             this.name,
             this.name,

--- a/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
@@ -31,8 +31,8 @@ data class Workspace(
     @SerializedName("last_used_at") val lastUsedAt: Instant,
 )
 
-fun Workspace.toAgentModels(): Set<WorkspaceAgentModel> {
-    val wam = this.latestBuild.resources.filter { it.agents != null }.flatMap { it.agents!! }.map { agent ->
+fun Workspace.toAgentModels(resources: List<WorkspaceResource> = this.latestBuild.resources): Set<WorkspaceAgentModel> {
+    val wam = resources.filter { it.agents != null }.flatMap { it.agents!! }.map { agent ->
         val workspaceWithAgentName = "${this.name}.${agent.name}"
         val wm = WorkspaceAgentModel(
             this.id,

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -256,7 +256,7 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                 deployments[dir] ?: try {
                     val url = Path.of(dir).resolve("url").readText()
                     val token = Path.of(dir).resolve("session").readText()
-                    DeploymentInfo(CoderRestClient(url.toURL(), token, settings.headerCommand))
+                    DeploymentInfo(CoderRestClient(url.toURL(), token, settings.headerCommand, null))
                 } catch (e: Exception) {
                     logger.error("Unable to create client from $dir", e)
                     DeploymentInfo(error = "Error trying to read $dir: ${e.message}")

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -620,7 +620,8 @@ class CoderWorkspacesStepView(val setNextButtonEnabled: (Boolean) -> Unit) : Cod
         poller?.cancel()
 
         logger.info("Configuring Coder CLI...")
-        cli.configSsh(tableOfWorkspaces.items, settings.headerCommand)
+        val workspaces = clientService.client.workspaces()
+        cli.configSsh(clientService.client.agents(workspaces), settings.headerCommand)
 
         // The config directory can be used to pull the URL and token in
         // order to query this workspace's status in other flows, for

--- a/src/test/groovy/CoderCLIManagerTest.groovy
+++ b/src/test/groovy/CoderCLIManagerTest.groovy
@@ -413,7 +413,7 @@ class CoderCLIManagerTest extends Specification {
                 .replace("/tmp/coder-gateway/test.coder.invalid/coder-linux-amd64", CoderCLIManager.escape(ccm.localBinaryPath.toString()))
 
         when:
-        ccm.configSsh(workspaces.collect { DataGen.workspace(it) }, headerCommand)
+        ccm.configSsh(workspaces.collect { DataGen.workspaceAgentModel(it) }, headerCommand)
 
         then:
         sshConfigPath.toFile().text == expectedConf
@@ -473,7 +473,7 @@ class CoderCLIManagerTest extends Specification {
         def ccm = new CoderCLIManager(new URL("https://test.coder.invalid"), tmpdir)
 
         when:
-        ccm.configSsh(["foo", "bar"].collect { DataGen.workspace(it) }, headerCommand)
+        ccm.configSsh(["foo", "bar"].collect { DataGen.workspaceAgentModel(it) }, headerCommand)
 
         then:
         thrown(Exception)

--- a/src/test/groovy/CoderGatewayConnectionProviderTest.groovy
+++ b/src/test/groovy/CoderGatewayConnectionProviderTest.groovy
@@ -1,0 +1,114 @@
+package com.coder.gateway
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class CoderGatewayConnectionProviderTest extends Specification {
+    @Shared
+    def agents = [
+        agent_name_3: "b0e4c54d-9ba9-4413-8512-11ca1e826a24",
+        agent_name_2: "fb3daea4-da6b-424d-84c7-36b90574cfef",
+        agent_name: "9a920eee-47fb-4571-9501-e4b3120c12f2",
+    ]
+    def oneAgent = [
+        agent_name_3: "b0e4c54d-9ba9-4413-8512-11ca1e826a24"
+    ]
+
+    def "gets matching agent"() {
+        expect:
+        def ws = DataGen.workspace("ws", agents)
+        CoderGatewayConnectionProvider.getMatchingAgent(parameters, ws).agentID == UUID.fromString(expected)
+
+        where:
+        parameters                                         | expected
+        [agent:    "agent_name"]                           | "9a920eee-47fb-4571-9501-e4b3120c12f2"
+        [agent_id: "9a920eee-47fb-4571-9501-e4b3120c12f2"] | "9a920eee-47fb-4571-9501-e4b3120c12f2"
+        [agent:    "agent_name_2"]                         | "fb3daea4-da6b-424d-84c7-36b90574cfef"
+        [agent_id: "fb3daea4-da6b-424d-84c7-36b90574cfef"] | "fb3daea4-da6b-424d-84c7-36b90574cfef"
+        [agent:    "agent_name_3"]                         | "b0e4c54d-9ba9-4413-8512-11ca1e826a24"
+        [agent_id: "b0e4c54d-9ba9-4413-8512-11ca1e826a24"] | "b0e4c54d-9ba9-4413-8512-11ca1e826a24"
+
+        // Prefer agent_id.
+        [agent: "agent_name", agent_id: "b0e4c54d-9ba9-4413-8512-11ca1e826a24"] | "b0e4c54d-9ba9-4413-8512-11ca1e826a24"
+    }
+
+    def "fails to get matching agent"() {
+        when:
+        def ws = DataGen.workspace("ws", agents)
+        CoderGatewayConnectionProvider.getMatchingAgent(parameters, ws)
+
+        then:
+        def err = thrown(expected)
+        err.message.contains(message)
+
+        where:
+        parameters                                         | expected                 | message
+        [:]                                                | MissingArgumentException | "Unable to determine"
+        [agent: ""]                                        | MissingArgumentException | "Unable to determine"
+        [agent_id: ""]                                     | MissingArgumentException | "Unable to determine"
+        [agent: null]                                      | MissingArgumentException | "Unable to determine"
+        [agent_id: null]                                   | MissingArgumentException | "Unable to determine"
+        [agent: "ws"]                                      | IllegalArgumentException | "agent named"
+        [agent: "ws.agent_name"]                           | IllegalArgumentException | "agent named"
+        [agent: "agent_name_4"]                            | IllegalArgumentException | "agent named"
+        [agent_id: "not-a-uuid"]                           | IllegalArgumentException | "agent with ID"
+        [agent_id: "ceaa7bcf-1612-45d7-b484-2e0da9349168"] | IllegalArgumentException | "agent with ID"
+
+        // Will ignore agent if agent_id is set even if agent matches.
+        [agent: "agent_name", agent_id: "ceaa7bcf-1612-45d7-b484-2e0da9349168"] | IllegalArgumentException | "agent with ID"
+    }
+
+    def "gets the first agent when workspace has only one"() {
+        expect:
+        def ws = DataGen.workspace("ws", oneAgent)
+        CoderGatewayConnectionProvider.getMatchingAgent(parameters, ws).agentID == UUID.fromString("b0e4c54d-9ba9-4413-8512-11ca1e826a24")
+
+        where:
+        parameters << [
+            [:],
+            [agent: ""],
+            [agent_id: ""],
+            [agent: null],
+            [agent_id: null],
+        ]
+    }
+
+    def "fails to get agent when workspace has only one"() {
+        when:
+        def ws = DataGen.workspace("ws", oneAgent)
+        CoderGatewayConnectionProvider.getMatchingAgent(parameters, ws)
+
+        then:
+        def err = thrown(expected)
+        err.message.contains(message)
+
+        where:
+        parameters                                         | expected                 | message
+        [agent:    "ws"]                                   | IllegalArgumentException | "agent named"
+        [agent:    "ws.agent_name_3"]                      | IllegalArgumentException | "agent named"
+        [agent:    "agent_name_4"]                         | IllegalArgumentException | "agent named"
+        [agent_id: "ceaa7bcf-1612-45d7-b484-2e0da9349168"] | IllegalArgumentException | "agent with ID"
+    }
+
+    def "fails to get agent from workspace without agents"() {
+        when:
+        def ws = DataGen.workspace("ws")
+        CoderGatewayConnectionProvider.getMatchingAgent(parameters, ws)
+
+        then:
+        def err = thrown(expected)
+        err.message.contains(message)
+
+        where:
+        parameters                                         | expected                 | message
+        [:]                                                | IllegalArgumentException | "has no agents"
+        [agent: ""]                                        | IllegalArgumentException | "has no agents"
+        [agent_id: ""]                                     | IllegalArgumentException | "has no agents"
+        [agent: null]                                      | IllegalArgumentException | "has no agents"
+        [agent_id: null]                                   | IllegalArgumentException | "has no agents"
+        [agent:    "agent_name"]                           | IllegalArgumentException | "has no agents"
+        [agent_id: "9a920eee-47fb-4571-9501-e4b3120c12f2"] | IllegalArgumentException | "has no agents"
+    }
+}

--- a/src/test/groovy/CoderRestClientTest.groovy
+++ b/src/test/groovy/CoderRestClientTest.groovy
@@ -1,9 +1,126 @@
 package com.coder.gateway.sdk
 
-import spock.lang.*
+import com.coder.gateway.sdk.convertors.InstantConverter
+import com.coder.gateway.sdk.v2.models.Workspace
+import com.coder.gateway.sdk.v2.models.WorkspaceResource
+import com.coder.gateway.sdk.v2.models.WorkspacesResponse
+import com.google.gson.GsonBuilder
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import spock.lang.IgnoreIf
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.net.ssl.HttpsURLConnection
+import java.time.Instant
 
 @Unroll
 class CoderRestClientTest extends Specification {
+    /**
+     * Create, start, and return a server that mocks the Coder API.
+     *
+     * The resources map to the workspace index (to avoid having to manually hardcode IDs everywhere since you cannot
+     * use variables in the where blocks).
+     */
+    def mockServer(List<Workspace> workspaces, List<List<WorkspaceResource>> resources = []) {
+        HttpServer srv = HttpServer.create(new InetSocketAddress(0), 0)
+        srv.createContext("/", new HttpHandler() {
+            void handle(HttpExchange exchange) {
+                int code = HttpURLConnection.HTTP_NOT_FOUND
+                String response = "not found"
+                try {
+                    def matcher = exchange.requestURI.path =~ /\/api\/v2\/templateversions\/([^\/]+)\/resources/
+                    if (matcher.size() == 1) {
+                        UUID templateVersionId = UUID.fromString(matcher[0][1])
+                        int idx = workspaces.findIndexOf { it.latestBuild.templateVersionID == templateVersionId }
+                        code = HttpURLConnection.HTTP_OK
+                        response = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantConverter())
+                                .create().toJson(resources[idx])
+                    } else if (exchange.requestURI.path == "/api/v2/workspaces") {
+                        code = HttpsURLConnection.HTTP_OK
+                        response = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantConverter())
+                                .create().toJson(new WorkspacesResponse(workspaces, workspaces.size()))
+                    }
+                } catch (error) {
+                    // This will be a developer error.
+                    code = HttpURLConnection.HTTP_INTERNAL_ERROR
+                    response = error.message
+                    println(error.message) // Print since it will not show up in the error.
+                }
+
+                byte[] body = response.getBytes()
+                exchange.sendResponseHeaders(code, body.length)
+                exchange.responseBody.write(body)
+                exchange.close()
+            }
+        })
+        srv.start()
+        return [srv, "http://localhost:" + srv.address.port]
+    }
+
+    def "gets workspaces"() {
+        given:
+        def (srv, url) = mockServer(workspaces)
+        def client = new CoderRestClient(new URL(url), "token", null, "test")
+
+        expect:
+        client.workspaces()*.name == expected
+
+        cleanup:
+        srv.stop(0)
+
+        where:
+        workspaces                                           | expected
+        []                                                   | []
+        [DataGen.workspace("ws1")]                           | ["ws1"]
+        [DataGen.workspace("ws1"), DataGen.workspace("ws2")] | ["ws1", "ws2"]
+    }
+
+    def "gets resources"() {
+        given:
+        def (srv, url) = mockServer(workspaces, resources)
+        def client = new CoderRestClient(new URL(url), "token", null, "test")
+
+        expect:
+        client.agents(workspaces).collect { it.agentID.toString() } == expected
+
+        cleanup:
+        srv.stop(0)
+
+        where:
+        workspaces << [
+                [],
+                [DataGen.workspace("ws1", [agent1: "3f51da1d-306f-4a40-ac12-62bda5bc5f9a"])],
+                [DataGen.workspace("ws1", [agent1: "3f51da1d-306f-4a40-ac12-62bda5bc5f9a"])],
+                [DataGen.workspace("ws1", [agent1: "3f51da1d-306f-4a40-ac12-62bda5bc5f9a"]),
+                 DataGen.workspace("ws2"),
+                 DataGen.workspace("ws3")],
+        ]
+        resources << [
+                [],
+                [[]],
+                [[DataGen.resource("agent2", "968eea5e-8787-439d-88cd-5bc440216a34"),
+                  DataGen.resource("agent3", "72fbc97b-952c-40c8-b1e5-7535f4407728")]],
+                [[],
+                 [DataGen.resource("agent2", "968eea5e-8787-439d-88cd-5bc440216a34"),
+                  DataGen.resource("agent3", "72fbc97b-952c-40c8-b1e5-7535f4407728")],
+                 []],
+        ]
+        expected << [
+                // Nothing, so no agents.
+                [],
+                // One workspace with an agent, but resources get overridden by the resources endpoint that returns
+                // nothing so we end up with a workspace without an agent.
+                ["null"],
+                // One workspace with an agent, but resources get overridden by the resources endpoint.
+                ["968eea5e-8787-439d-88cd-5bc440216a34", "72fbc97b-952c-40c8-b1e5-7535f4407728"],
+                // Multiple workspaces but only one has resources from the resources endpoint.
+                ["null", "968eea5e-8787-439d-88cd-5bc440216a34", "72fbc97b-952c-40c8-b1e5-7535f4407728", "null"],
+        ]
+    }
+
     def "gets headers"() {
         expect:
         CoderRestClient.getHeaders(new URL("http://localhost"), command) == expected

--- a/src/test/groovy/CoderWorkspacesStepViewTest.groovy
+++ b/src/test/groovy/CoderWorkspacesStepViewTest.groovy
@@ -9,46 +9,46 @@ class CoderWorkspacesStepViewTest extends Specification {
         def table = new WorkspacesTable()
         table.listTableModel.items = List.of(
                 // An off workspace.
-                DataGen.workspace("ws1", "ws1"),
+                DataGen.workspaceAgentModel("ws1", "ws1"),
 
                 // On workspaces.
-                DataGen.workspace("agent1", "ws2"),
-                DataGen.workspace("agent2", "ws2"),
-                DataGen.workspace("agent3", "ws3"),
+                DataGen.workspaceAgentModel("agent1", "ws2"),
+                DataGen.workspaceAgentModel("agent2", "ws2"),
+                DataGen.workspaceAgentModel("agent3", "ws3"),
 
                 // Another off workspace.
-                DataGen.workspace("ws4", "ws4"),
+                DataGen.workspaceAgentModel("ws4", "ws4"),
 
                 // In practice we do not list both agents and workspaces
                 // together but here test that anyway with an agent first and
                 // then with a workspace first.
-                DataGen.workspace("agent2", "ws5"),
-                DataGen.workspace("ws5", "ws5"),
-                DataGen.workspace("ws6", "ws6"),
-                DataGen.workspace("agent3", "ws6"),
+                DataGen.workspaceAgentModel("agent2", "ws5"),
+                DataGen.workspaceAgentModel("ws5", "ws5"),
+                DataGen.workspaceAgentModel("ws6", "ws6"),
+                DataGen.workspaceAgentModel("agent3", "ws6"),
         )
 
         expect:
         table.getNewSelection(selected) == expected
 
         where:
-        selected                           | expected
-        null                               | -1 // No selection.
-        DataGen.workspace("gone", "gone")  | -1 // No workspace that matches.
-        DataGen.workspace("ws1", "ws1")    | 0  // Workspace exact match.
-        DataGen.workspace("gone", "ws1")   | 0  // Agent gone, select workspace.
-        DataGen.workspace("ws2", "ws2")    | 1  // Workspace gone, select first agent.
-        DataGen.workspace("agent1", "ws2") | 1  // Agent exact match.
-        DataGen.workspace("agent2", "ws2") | 2  // Agent exact match.
-        DataGen.workspace("ws3", "ws3")    | 3  // Workspace gone, select first agent.
-        DataGen.workspace("agent3", "ws3") | 3  // Agent exact match.
-        DataGen.workspace("gone", "ws4")   | 4  // Agent gone, select workspace.
-        DataGen.workspace("ws4", "ws4")    | 4  // Workspace exact match.
-        DataGen.workspace("agent2", "ws5") | 5  // Agent exact match.
-        DataGen.workspace("gone", "ws5")   | 5  // Agent gone, another agent comes first.
-        DataGen.workspace("ws5", "ws5")    | 6  // Workspace exact match.
-        DataGen.workspace("ws6", "ws6")    | 7  // Workspace exact match.
-        DataGen.workspace("gone", "ws6")   | 7  // Agent gone, workspace comes first.
-        DataGen.workspace("agent3", "ws6") | 8  // Agent exact match.
+        selected                                     | expected
+        null                                         | -1 // No selection.
+        DataGen.workspaceAgentModel("gone", "gone")  | -1 // No workspace that matches.
+        DataGen.workspaceAgentModel("ws1", "ws1")    | 0  // Workspace exact match.
+        DataGen.workspaceAgentModel("gone", "ws1")   | 0  // Agent gone, select workspace.
+        DataGen.workspaceAgentModel("ws2", "ws2")    | 1  // Workspace gone, select first agent.
+        DataGen.workspaceAgentModel("agent1", "ws2") | 1  // Agent exact match.
+        DataGen.workspaceAgentModel("agent2", "ws2") | 2  // Agent exact match.
+        DataGen.workspaceAgentModel("ws3", "ws3")    | 3  // Workspace gone, select first agent.
+        DataGen.workspaceAgentModel("agent3", "ws3") | 3  // Agent exact match.
+        DataGen.workspaceAgentModel("gone", "ws4")   | 4  // Agent gone, select workspace.
+        DataGen.workspaceAgentModel("ws4", "ws4")    | 4  // Workspace exact match.
+        DataGen.workspaceAgentModel("agent2", "ws5") | 5  // Agent exact match.
+        DataGen.workspaceAgentModel("gone", "ws5")   | 5  // Agent gone, another agent comes first.
+        DataGen.workspaceAgentModel("ws5", "ws5")    | 6  // Workspace exact match.
+        DataGen.workspaceAgentModel("ws6", "ws6")    | 7  // Workspace exact match.
+        DataGen.workspaceAgentModel("gone", "ws6")   | 7  // Agent gone, workspace comes first.
+        DataGen.workspaceAgentModel("agent3", "ws6") | 8  // Agent exact match.
     }
 }

--- a/src/test/groovy/CoderWorkspacesStepViewTest.groovy
+++ b/src/test/groovy/CoderWorkspacesStepViewTest.groovy
@@ -9,7 +9,7 @@ class CoderWorkspacesStepViewTest extends Specification {
         def table = new WorkspacesTable()
         table.listTableModel.items = List.of(
                 // An off workspace.
-                DataGen.workspaceAgentModel("ws1", "ws1"),
+                DataGen.workspaceAgentModel("ws1"),
 
                 // On workspaces.
                 DataGen.workspaceAgentModel("agent1", "ws2"),
@@ -17,14 +17,14 @@ class CoderWorkspacesStepViewTest extends Specification {
                 DataGen.workspaceAgentModel("agent3", "ws3"),
 
                 // Another off workspace.
-                DataGen.workspaceAgentModel("ws4", "ws4"),
+                DataGen.workspaceAgentModel("ws4"),
 
                 // In practice we do not list both agents and workspaces
                 // together but here test that anyway with an agent first and
                 // then with a workspace first.
                 DataGen.workspaceAgentModel("agent2", "ws5"),
-                DataGen.workspaceAgentModel("ws5", "ws5"),
-                DataGen.workspaceAgentModel("ws6", "ws6"),
+                DataGen.workspaceAgentModel("ws5"),
+                DataGen.workspaceAgentModel("ws6"),
                 DataGen.workspaceAgentModel("agent3", "ws6"),
         )
 
@@ -35,19 +35,19 @@ class CoderWorkspacesStepViewTest extends Specification {
         selected                                     | expected
         null                                         | -1 // No selection.
         DataGen.workspaceAgentModel("gone", "gone")  | -1 // No workspace that matches.
-        DataGen.workspaceAgentModel("ws1", "ws1")    | 0  // Workspace exact match.
+        DataGen.workspaceAgentModel("ws1")           | 0  // Workspace exact match.
         DataGen.workspaceAgentModel("gone", "ws1")   | 0  // Agent gone, select workspace.
-        DataGen.workspaceAgentModel("ws2", "ws2")    | 1  // Workspace gone, select first agent.
+        DataGen.workspaceAgentModel("ws2")           | 1  // Workspace gone, select first agent.
         DataGen.workspaceAgentModel("agent1", "ws2") | 1  // Agent exact match.
         DataGen.workspaceAgentModel("agent2", "ws2") | 2  // Agent exact match.
-        DataGen.workspaceAgentModel("ws3", "ws3")    | 3  // Workspace gone, select first agent.
+        DataGen.workspaceAgentModel("ws3")           | 3  // Workspace gone, select first agent.
         DataGen.workspaceAgentModel("agent3", "ws3") | 3  // Agent exact match.
         DataGen.workspaceAgentModel("gone", "ws4")   | 4  // Agent gone, select workspace.
-        DataGen.workspaceAgentModel("ws4", "ws4")    | 4  // Workspace exact match.
+        DataGen.workspaceAgentModel("ws4")           | 4  // Workspace exact match.
         DataGen.workspaceAgentModel("agent2", "ws5") | 5  // Agent exact match.
         DataGen.workspaceAgentModel("gone", "ws5")   | 5  // Agent gone, another agent comes first.
-        DataGen.workspaceAgentModel("ws5", "ws5")    | 6  // Workspace exact match.
-        DataGen.workspaceAgentModel("ws6", "ws6")    | 7  // Workspace exact match.
+        DataGen.workspaceAgentModel("ws5")           | 6  // Workspace exact match.
+        DataGen.workspaceAgentModel("ws6")           | 7  // Workspace exact match.
         DataGen.workspaceAgentModel("gone", "ws6")   | 7  // Agent gone, workspace comes first.
         DataGen.workspaceAgentModel("agent3", "ws6") | 8  // Agent exact match.
     }

--- a/src/test/groovy/DataGen.groovy
+++ b/src/test/groovy/DataGen.groovy
@@ -5,12 +5,19 @@ import com.coder.gateway.sdk.v2.models.WorkspaceStatus
 import com.coder.gateway.sdk.v2.models.WorkspaceTransition
 
 class DataGen {
-    static WorkspaceAgentModel workspace(String name, String workspaceName = name) {
+    // Create a random workspace agent model.  If the workspace name is omitted
+    // then return a model without any agent bits, similar to what
+    // toAgentModels() does if the workspace does not specify any agents.
+    // TODO: Maybe better to randomly generate the workspace and then call
+    //       toAgentModels() on it.  Also the way an "agent" model can have no
+    //       agent in it seems weird; can we refactor to remove
+    //       WorkspaceAgentModel and use the original structs from the API?
+    static WorkspaceAgentModel workspace(String name, String workspaceName = "", UUID agentId = UUID.randomUUID()) {
         return new WorkspaceAgentModel(
+                workspaceName == "" ? null : agentId,
                 UUID.randomUUID(),
-                UUID.randomUUID(),
-                workspaceName,
-                name,
+                workspaceName == "" ? name : workspaceName,
+                workspaceName == "" ? name : (workspaceName + "." + name),
                 UUID.randomUUID(),
                 "template-name",
                 "template-icon-path",

--- a/src/test/groovy/DataGen.groovy
+++ b/src/test/groovy/DataGen.groovy
@@ -12,7 +12,7 @@ class DataGen {
     //       toAgentModels() on it.  Also the way an "agent" model can have no
     //       agent in it seems weird; can we refactor to remove
     //       WorkspaceAgentModel and use the original structs from the API?
-    static WorkspaceAgentModel workspace(String name, String workspaceName = "", UUID agentId = UUID.randomUUID()) {
+    static WorkspaceAgentModel workspaceAgentModel(String name, String workspaceName = "", UUID agentId = UUID.randomUUID()) {
         return new WorkspaceAgentModel(
                 workspaceName == "" ? null : agentId,
                 UUID.randomUUID(),

--- a/src/test/groovy/DataGen.groovy
+++ b/src/test/groovy/DataGen.groovy
@@ -31,10 +31,8 @@ class DataGen {
         )
     }
 
-    static Workspace workspace(String name, Map<String, String> agents = [:]) {
-        UUID wsId = UUID.randomUUID()
-        UUID ownerId = UUID.randomUUID()
-        List<WorkspaceResource> resources = agents.collect{ agentName, agentId -> new WorkspaceResource(
+    static WorkspaceResource resource(String agentName, String agentId){
+        return new WorkspaceResource(
                 UUID.randomUUID(),      // id
                 new Date().toInstant(), // created_at
                 UUID.randomUUID(),      // job_id
@@ -70,7 +68,13 @@ class DataGen {
                 )),
                 null,                   // metadata
                 0,                      // daily_cost
-        )}
+        )
+    }
+
+    static Workspace workspace(String name, Map<String, String> agents = [:]) {
+        UUID wsId = UUID.randomUUID()
+        UUID ownerId = UUID.randomUUID()
+        List<WorkspaceResource> resources = agents.collect{ resource(it.key, it.value)}
         return new Workspace(
                 wsId,
                 new Date().toInstant(), // created_at

--- a/src/test/groovy/DataGen.groovy
+++ b/src/test/groovy/DataGen.groovy
@@ -1,8 +1,7 @@
 import com.coder.gateway.models.WorkspaceAgentModel
 import com.coder.gateway.models.WorkspaceAndAgentStatus
 import com.coder.gateway.models.WorkspaceVersionStatus
-import com.coder.gateway.sdk.v2.models.WorkspaceStatus
-import com.coder.gateway.sdk.v2.models.WorkspaceTransition
+import com.coder.gateway.sdk.v2.models.*
 
 class DataGen {
     // Create a random workspace agent model.  If the workspace name is omitted
@@ -29,6 +28,96 @@ class DataGen {
                 null,
                 null,
                 null
+        )
+    }
+
+    static Workspace workspace(String name, Map<String, String> agents = [:]) {
+        UUID wsId = UUID.randomUUID()
+        UUID ownerId = UUID.randomUUID()
+        List<WorkspaceResource> resources = agents.collect{ agentName, agentId -> new WorkspaceResource(
+                UUID.randomUUID(),      // id
+                new Date().toInstant(), // created_at
+                UUID.randomUUID(),      // job_id
+                WorkspaceTransition.START,
+                "type",
+                "name",
+                false,                  // hide
+                "icon",
+                List.of(new WorkspaceAgent(
+                        UUID.fromString(agentId),
+                        new Date().toInstant(),    // created_at
+                        new Date().toInstant(),    // updated_at
+                        null,                      // first_connected_at
+                        null,                      // last_connected_at
+                        null,                      // disconnected_at
+                        WorkspaceAgentStatus.CONNECTED,
+                        agentName,
+                        UUID.randomUUID(),         // resource_id
+                        null,                      // instance_id
+                        "arch",                    // architecture
+                        [:],                       // environment_variables
+                        "os",                      // operating_system
+                        null,                      // startup_script
+                        null,                      // directory
+                        null,                      // expanded_directory
+                        "version",                 // version
+                        List.of(),                 // apps
+                        null,                      // latency
+                        0,                         // connection_timeout_seconds
+                        "url",                     // troubleshooting_url
+                        WorkspaceAgentLifecycleState.READY,
+                        false,                     // login_before_ready
+                )),
+                null,                   // metadata
+                0,                      // daily_cost
+        )}
+        return new Workspace(
+                wsId,
+                new Date().toInstant(), // created_at
+                new Date().toInstant(), // updated_at
+                ownerId,
+                "owner-name",
+                UUID.randomUUID(),      // template_id
+                "template-name",
+                "template-display-name",
+                "template-icon",
+                false,                  // template_allow_user_cancel_workspace_jobs
+                new WorkspaceBuild(
+                        UUID.randomUUID(),      // id
+                        new Date().toInstant(), // created_at
+                        new Date().toInstant(), // updated_at
+                        wsId,
+                        name,
+                        ownerId,
+                        "owner-name",
+                        UUID.randomUUID(),      // template_version_id
+                        0,                      // build_number
+                        WorkspaceTransition.START,
+                        UUID.randomUUID(),      // initiator_id
+                        "initiator-name",
+                        new ProvisionerJob(
+                                UUID.randomUUID(),      // id
+                                new Date().toInstant(), // created_at
+                                null,                   // started_at
+                                null,                   // completed_at
+                                null,                   // canceled_at
+                                null,                   // error
+                                ProvisionerJobStatus.SUCCEEDED,
+                                null,                   // worker_id
+                                UUID.randomUUID(),      // file_id
+                                [:],                    // tags
+                        ),
+                        BuildReason.INITIATOR,
+                        resources,
+                        null,                   // deadline
+                        WorkspaceStatus.RUNNING,
+                        0,                      // daily_cost
+                ),
+                false,                  // outdated
+                name,
+                null,                   // autostart_schedule
+                null,                   // ttl_ms
+                new Date().toInstant(), // last_used_at
         )
     }
 }

--- a/src/test/groovy/DataGen.groovy
+++ b/src/test/groovy/DataGen.groovy
@@ -8,6 +8,7 @@ class DataGen {
     static WorkspaceAgentModel workspace(String name, String workspaceName = name) {
         return new WorkspaceAgentModel(
                 UUID.randomUUID(),
+                UUID.randomUUID(),
                 workspaceName,
                 name,
                 UUID.randomUUID(),


### PR DESCRIPTION
I just copied the way the Coder CLI does it.

This way, it will not drop hosts when it reconfigures SSH if those hosts happen to be off.  I am not sure if the agents missing from the workspaces response is intended, but since the CLI does it this way I assume it is intentional.

I tested both connection flows and both worked first try, which has me extremely suspicious but I guess the change is pretty straightforward.

Fixes https://github.com/coder/jetbrains-coder/issues/290