### PR TITLE
Adding Header Commands To The Download CLI phase

### DIFF
--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -180,8 +180,6 @@ class CoderCLIManager @JvmOverloads constructor(
      */
     fun login(token: String): String {
         logger.info("Storing CLI credentials in $coderConfigPath")
-        logger.info("Storing CLI credentials in $coderConfigPath")
-
         return exec(
             "login",
             deploymentURL.toString(),

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -101,11 +101,19 @@ class CoderCLIManager @JvmOverloads constructor(
     fun downloadCLI(): Boolean {
         val etag = getBinaryETag()
         val conn = remoteBinaryURL.openConnection() as HttpURLConnection
+        if (settings.headerCommand.isNotBlank()){
+//            get headers
+            val headersFromHeaderCommand =CoderRestClient.getHeaders(deploymentURL,settings.headerCommand)
+            for ((key, value) in headersFromHeaderCommand) {
+                conn.setRequestProperty(key, value)
+            }
+        }
         if (etag != null) {
             logger.info("Found existing binary at $localBinaryPath; calculated hash as $etag")
             conn.setRequestProperty("If-None-Match", "\"$etag\"")
         }
         conn.setRequestProperty("Accept-Encoding", "gzip")
+
         if (conn is HttpsURLConnection) {
             conn.sslSocketFactory = coderSocketFactory(settings)
             conn.hostnameVerifier = CoderHostnameVerifier(settings.tlsAlternateHostname)
@@ -172,6 +180,8 @@ class CoderCLIManager @JvmOverloads constructor(
      */
     fun login(token: String): String {
         logger.info("Storing CLI credentials in $coderConfigPath")
+        logger.info("Storing CLI credentials in $coderConfigPath")
+
         return exec(
             "login",
             deploymentURL.toString(),
@@ -179,6 +189,8 @@ class CoderCLIManager @JvmOverloads constructor(
             token,
             "--global-config",
             coderConfigPath.toString(),
+            "--header-command",
+            settings.headerCommand
         )
     }
 
@@ -364,6 +376,7 @@ class CoderCLIManager @JvmOverloads constructor(
     private fun exec(vararg args: String): String {
         val stdout = ProcessExecutor()
             .command(localBinaryPath.toString(), *args)
+            .environment("CODER_HEADER_COMMAND",settings.headerCommand)
             .exitValues(0)
             .readOutput(true)
             .execute()

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -184,9 +184,7 @@ class CoderCLIManager @JvmOverloads constructor(
             "--token",
             token,
             "--global-config",
-            coderConfigPath.toString(),
-            "--header-command",
-            settings.headerCommand
+            coderConfigPath.toString()
         )
     }
 

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -102,7 +102,7 @@ class CoderCLIManager @JvmOverloads constructor(
         val etag = getBinaryETag()
         val conn = remoteBinaryURL.openConnection() as HttpURLConnection
         if (settings.headerCommand.isNotBlank()){
-            val headersFromHeaderCommand =CoderRestClient.getHeaders(deploymentURL,settings.headerCommand)
+            val headersFromHeaderCommand =CoderRestClient.getHeaders(deploymentURL, settings.headerCommand)
             for ((key, value) in headersFromHeaderCommand) {
                 conn.setRequestProperty(key, value)
             }
@@ -370,7 +370,7 @@ class CoderCLIManager @JvmOverloads constructor(
     private fun exec(vararg args: String): String {
         val stdout = ProcessExecutor()
             .command(localBinaryPath.toString(), *args)
-            .environment("CODER_HEADER_COMMAND",settings.headerCommand)
+            .environment("CODER_HEADER_COMMAND", settings.headerCommand)
             .exitValues(0)
             .readOutput(true)
             .execute()

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -101,8 +101,8 @@ class CoderCLIManager @JvmOverloads constructor(
     fun downloadCLI(): Boolean {
         val etag = getBinaryETag()
         val conn = remoteBinaryURL.openConnection() as HttpURLConnection
-        if (settings.headerCommand.isNotBlank()){
-            val headersFromHeaderCommand =CoderRestClient.getHeaders(deploymentURL, settings.headerCommand)
+        if (settings.headerCommand.isNotBlank()) {
+            val headersFromHeaderCommand = CoderRestClient.getHeaders(deploymentURL, settings.headerCommand)
             for ((key, value) in headersFromHeaderCommand) {
                 conn.setRequestProperty(key, value)
             }
@@ -184,7 +184,7 @@ class CoderCLIManager @JvmOverloads constructor(
             "--token",
             token,
             "--global-config",
-            coderConfigPath.toString()
+            coderConfigPath.toString(),
         )
     }
 

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -102,7 +102,6 @@ class CoderCLIManager @JvmOverloads constructor(
         val etag = getBinaryETag()
         val conn = remoteBinaryURL.openConnection() as HttpURLConnection
         if (settings.headerCommand.isNotBlank()){
-//            get headers
             val headersFromHeaderCommand =CoderRestClient.getHeaders(deploymentURL,settings.headerCommand)
             for ((key, value) in headersFromHeaderCommand) {
                 conn.setRequestProperty(key, value)
@@ -113,7 +112,6 @@ class CoderCLIManager @JvmOverloads constructor(
             conn.setRequestProperty("If-None-Match", "\"$etag\"")
         }
         conn.setRequestProperty("Accept-Encoding", "gzip")
-
         if (conn is HttpsURLConnection) {
             conn.sslSocketFactory = coderSocketFactory(settings)
             conn.hostnameVerifier = CoderHostnameVerifier(settings.tlsAlternateHostname)


### PR DESCRIPTION
### Background:
The login phase of the JetBrains Coder plugin involves downloading a fresh CLI binary from the control plane. However, if the control plane is located behind a VPN or protected by Cloudflare, it requires passing relevant tokens to the download request to ensure a successful download. To handle this, JetBrains Coder introduces the concept of "header commands" as a means of adding these tokens.

### Changes Made:
This pull request addresses the need to support header commands by utilizing them  when downloading the CLI binary

### What's Included:
1. **Added Support for Header Commands:** This PR includes the necessary changes to enable the use of header commands during the CLI binary download process.

### Why This Matters:
Enabling header commands support for CLI binary downloads is crucial for ensuring the seamless operation of the JetBrains Coder plugin in environments where the control plane is protected by VPN or Cloudflare. This enhancement will improve the reliability and functionality of the plugin in such scenarios.

### How to Verify:
- Deploy the plugin with these changes.
- Attempt to log in to the JetBrains Coder plugin in an environment behind a VPN or protected by Cloudflare.
- Verify that the CLI binary download successfully uses the header commands to pass the required tokens.

Thank you for your time and consideration! 🙌