### PR TITLE
Remove HostName from SSH config

### DIFF
--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -234,7 +234,6 @@ class CoderCLIManager @JvmOverloads constructor(
             transform = {
                 """
                 Host ${getHostName(deploymentURL, it)}
-                  HostName coder.${it.name}
                   ProxyCommand ${proxyArgs.joinToString(" ")} ${it.name}
                   ConnectTimeout 0
                   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/fixtures/outputs/append-blank-newlines.conf
@@ -4,7 +4,6 @@
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/append-blank.conf
+++ b/src/test/fixtures/outputs/append-blank.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-blocks.conf
@@ -5,7 +5,6 @@ Host test2
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/append-no-newline.conf
+++ b/src/test/fixtures/outputs/append-no-newline.conf
@@ -4,7 +4,6 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-related-blocks.conf
@@ -11,7 +11,6 @@ some jetbrains config
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/header-command-windows.conf
+++ b/src/test/fixtures/outputs/header-command-windows.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  HostName coder.header
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "C:\Program Files\My Header Command\\"also has quotes\"\HeaderCommand.exe" ssh --stdio header
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/header-command.conf
+++ b/src/test/fixtures/outputs/header-command.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  HostName coder.header
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "my-header-command \"test\"" ssh --stdio header
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/fixtures/outputs/multiple-workspaces.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  HostName coder.foo
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
   ConnectTimeout 0
   StrictHostKeyChecking no
@@ -8,7 +7,6 @@ Host coder-jetbrains--foo--test.coder.invalid
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid
-  HostName coder.bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/fixtures/outputs/replace-end-no-newline.conf
@@ -3,7 +3,6 @@ Host test
 Host test2
   Port 443 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-end.conf
+++ b/src/test/fixtures/outputs/replace-end.conf
@@ -4,7 +4,6 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -5,7 +5,6 @@ some coder config
 # ------------END-CODER------------
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-middle.conf
+++ b/src/test/fixtures/outputs/replace-middle.conf
@@ -2,7 +2,6 @@ Host test
   Port 80
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-only.conf
+++ b/src/test/fixtures/outputs/replace-only.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no

--- a/src/test/fixtures/outputs/replace-start.conf
+++ b/src/test/fixtures/outputs/replace-start.conf
@@ -1,6 +1,5 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  HostName coder.foo-bar
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no


### PR DESCRIPTION
Having `HostName` causes errors in Gateway about the host not being found even though it seems to work in the end...but all those (many, many) errors make the logs noisy and maybe this is causing some instability in some cases.

I have no idea why Gateway is trying to connect to `HostName` when there is a `ProxyCommand` but it smells like a bug.

For now I removed `HostName` and there are no more errors.  It was just copied from how the Coder CLI does things so hopefully it is not actually required somehow because I have no idea why it was included in the first place.  Everything works for me without it.