### PR TITLE
Fix error with specific ssh configurations

### DIFF
--- a/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderCLIManager.kt
@@ -302,7 +302,7 @@ class CoderCLIManager @JvmOverloads constructor(
      */
     private fun writeSSHConfig(contents: String?) {
         if (contents != null) {
-            Files.createDirectories(sshConfigPath.parent)
+            sshConfigPath.parent.toFile().mkdirs()
             sshConfigPath.toFile().writeText(contents)
         }
     }


### PR DESCRIPTION
To create missing .ssh folder `Files.createDirectories(...)` is used which always tries to create a directory.
In some cases, especially when .ssh is actually a symbolic link this results in an uncatched `FileAlreadyExistsException` being thrown.

This PR mitigates this by replacing the folder creation with `File#mkdirs()` which checks the existence of the path before doing anything. 