### PR TITLE
add popup diaglog for missing IDE data on url handler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ pluginUntilBuild=241.*
 # verifier should be used after bumping versions to ensure compatibility in the
 # range.
 platformType=GW
-platformVersion=233.6745-EAP-CANDIDATE-SNAPSHOT
+platformVersion=233.14808-EAP-CANDIDATE-SNAPSHOT
 instrumentationCompiler=241.10840-EAP-CANDIDATE-SNAPSHOT
 platformDownloadSources=true
 verifyVersions=2023.3,2024.1

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -209,7 +209,7 @@ class CoderCLIManager(
      *
      * This can take supported features for testing purposes only.
      */
-    fun configSsh(workspaceNames: List<String>, feats: Features = features) {
+    fun configSsh(workspaceNames: Set<String>, feats: Features = features) {
         writeSSHConfig(modifySSHConfig(readSSHConfig(), workspaceNames, feats))
     }
 
@@ -232,7 +232,7 @@ class CoderCLIManager(
      * If features are not provided, calculate them based on the binary
      * version.
      */
-    private fun modifySSHConfig(contents: String?, workspaceNames: List<String>, feats: Features): String? {
+    private fun modifySSHConfig(contents: String?, workspaceNames: Set<String>, feats: Features): String? {
         val host = deploymentURL.safeHost()
         val startBlock = "# --- START CODER JETBRAINS $host"
         val endBlock = "# --- END CODER JETBRAINS $host"

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceStepView.kt
@@ -89,7 +89,7 @@ class CoderWorkspaceStepView(
     // Called with a boolean indicating whether IDE selection is complete.
     private val nextButtonEnabled: (Boolean) -> Unit,
 ) : CoderWizardStep {
-    private val cs = CoroutineScope(Dispatchers.Main)
+    private val cs = CoroutineScope(Dispatchers.IO)
     private var ideComboBoxModel = DefaultComboBoxModel<IdeWithStatus>()
     private var state: CoderWorkspacesStepSelection? = null
 
@@ -189,7 +189,7 @@ class CoderWorkspaceStepView(
                 logger.info("Configuring Coder CLI...")
                 cbIDE.renderer = IDECellRenderer("Configuring Coder CLI...")
                 withContext(Dispatchers.IO) {
-                    data.cliManager.configSsh(data.client.agentNames(data.workspaces))
+                    data.cliManager.configSsh(data.client.agentNames(data.workspaces).toSet())
                 }
 
                 val ides = suspendingRetryWithExponentialBackOff(
@@ -228,7 +228,7 @@ class CoderWorkspaceStepView(
                         cbIDE.renderer = IDECellRenderer(CoderGatewayBundle.message("gateway.connector.view.coder.retrieve-ides.failed.retry", humanizeDuration(remainingMs)))
                     },
                 )
-                withContext(Dispatchers.Main) {
+                withContext(Dispatchers.IO) {
                     ideComboBoxModel.addAll(ides)
                     cbIDE.selectedIndex = 0
                 }

--- a/src/test/kotlin/com/coder/gateway/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/gateway/cli/CoderCLIManagerTest.kt
@@ -295,12 +295,12 @@ internal class CoderCLIManagerTest {
                 .replace("/tmp/coder-gateway/test.coder.invalid/coder-linux-amd64", escape(ccm.localBinaryPath.toString()))
 
             // Add workspaces.
-            ccm.configSsh(it.workspaces, it.features ?: Features())
+            ccm.configSsh(it.workspaces.toSet(), it.features ?: Features())
 
             assertEquals(expectedConf, settings.sshConfigPath.toFile().readText())
 
             // Remove configuration.
-            ccm.configSsh(emptyList(), it.features ?: Features())
+            ccm.configSsh(emptySet(), it.features ?: Features())
 
             // Remove is the configuration we expect after removing.
             assertEquals(
@@ -330,7 +330,7 @@ internal class CoderCLIManagerTest {
 
             assertFailsWith(
                 exceptionClass = SSHConfigFormatException::class,
-                block = { ccm.configSsh(emptyList()) })
+                block = { ccm.configSsh(emptySet()) })
         }
     }
 
@@ -346,7 +346,7 @@ internal class CoderCLIManagerTest {
 
             assertFailsWith(
                 exceptionClass = Exception::class,
-                block = { ccm.configSsh(listOf("foo", "bar")) })
+                block = { ccm.configSsh(setOf("foo", "bar")) })
         }
     }
 


### PR DESCRIPTION
I really have no idea what I am doing, but this seems to work...

If the the `jetbrains-gateway://` URL handler request is missing `ide_product_code`, `ide_build_number`, i`de_path_on_host` (or `ide_download_link`), or `folder` then we will open up a dialog that goes through the ide selection box (step 2 from normal UI flow).

Any feedback is most welcome!