### PR TITLE
Bring parity with cli to header command

### DIFF
--- a/src/main/kotlin/com/coder/gateway/util/Headers.kt
+++ b/src/main/kotlin/com/coder/gateway/util/Headers.kt
@@ -1,7 +1,8 @@
 package com.coder.gateway.util
 
-import java.net.URL
 import org.zeroturnaround.exec.ProcessExecutor
+import java.io.OutputStream
+import java.net.URL
 
 private val newlineRegex = "\r?\n".toRegex()
 private val endingNewlineRegex = "\r?\n$".toRegex()
@@ -14,24 +15,36 @@ fun getHeaders(url: URL, headerCommand: String?): Map<String, String> {
         OS.WINDOWS -> Pair("cmd.exe", "/c")
         else -> Pair("sh", "-c")
     }
-    return ProcessExecutor()
+    val output = ProcessExecutor()
         .command(shell, caller, headerCommand)
         .environment("CODER_URL", url.toString())
+        // By default stderr is in the output, but we want to ignore it.  stderr
+        // will still be included in the exception if something goes wrong.
+        .redirectError(OutputStream.nullOutputStream())
         .exitValues(0)
         .readOutput(true)
         .execute()
         .outputUTF8()
+
+    // The Coder CLI will allow no output, but not blank lines.  Possibly we
+    // should skip blank lines, but it is better to have parity so commands will
+    // not sometimes work in one context and not another.
+    return if (output == "") mapOf() else output
         .replaceFirst(endingNewlineRegex, "")
         .split(newlineRegex)
         .associate {
             // Header names cannot be blank or contain whitespace and the Coder
-            // CLI requires that there be an equals sign (the value can be blank
-            // though).  The second case is taken care of by the destructure
-            // here, as it will throw if there are not enough parts.
-            val (name, value) = it.split("=", limit=2)
-            if (name.contains(" ") || name == "") {
-                throw Exception("\"$name\" is not a valid header name")
+            // CLI requires there be an equals sign (the value can be blank).
+            val parts = it.split("=", limit=2)
+            if (it.isBlank()) {
+                throw Exception("Blank lines are not allowed")
+            } else if (parts.size != 2) {
+                throw Exception("Header \"$it\" does not have two parts")
+            } else if (parts[0].isBlank()) {
+                throw Exception("Header name is missing in \"$it\"")
+            } else if (parts[0].contains(" ")) {
+                throw Exception("Header name cannot contain spaces, got \"${parts[0]}\"")
             }
-            name to value
+            parts[0] to parts[1]
         }
 }


### PR DESCRIPTION
- Do not include stderr.
- Allow no output.

Closes #404 