### PR TITLE
Make version column display outdated status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- The version column now displays "Up to date" or "Outdated" instead of
+  duplicating the status column.
+
 ## 2.11.7 - 2024-05-22
 
 ### Fixed

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -893,7 +893,13 @@ class WorkspacesTableModel : ListTableModel<WorkspaceAgentListModel>(
 
     private class WorkspaceVersionColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(workspace: WorkspaceAgentListModel?): String? {
-            return workspace?.status?.label
+            return if (workspace == null) {
+                "Unknown"
+            } else if (workspace.workspace.outdated) {
+                "Outdated"
+            } else {
+                "Up to date"
+            }
         }
 
         override fun getRenderer(item: WorkspaceAgentListModel?): TableCellRenderer {


### PR DESCRIPTION
Before it was (probably on accident) just duplicating the status column.

Now it looks like this:

![screenshot](https://github.com/coder/jetbrains-coder/assets/45609798/dadd81fd-4972-4f15-879c-6189b6609075)
