### PR TITLE
chore: use background hostname for admin tasks

### DIFF
--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -10,6 +10,7 @@ import com.coder.gateway.util.humanizeDuration
 import com.coder.gateway.util.isCancellation
 import com.coder.gateway.util.isWorkerTimeout
 import com.coder.gateway.util.suspendingRetryWithExponentialBackOff
+import com.coder.gateway.cli.CoderCLIManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -142,7 +143,7 @@ class CoderRemoteConnectionHandle {
             authType = AuthType.OPEN_SSH
         }
         val backgroundCredentials = RemoteCredentialsHolder().apply {
-            setHost(workspace.hostname)
+            setHost(CoderCLIManager.getBackgroundHostName(workspace.hostname))
             userName = "coder"
             port = 22
             authType = AuthType.OPEN_SSH

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -357,7 +357,7 @@ class CoderRemoteConnectionHandle {
     private fun exec(workspace: WorkspaceProjectIDE, command: String): String {
         logger.info("Running command `$command` in ${workspace.hostname}:${workspace.idePathOnHost}/bin...")
         return ProcessExecutor()
-            .command("ssh", "-t", workspace.hostname, "cd '${workspace.idePathOnHost}' ; cd bin ; $command")
+            .command("ssh", "-t", CoderCLIManager.getBackgroundHostName(workspace.hostname), "cd '${workspace.idePathOnHost}' ; cd bin ; $command")
             .exitValues(0)
             .readOutput(true)
             .execute()

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -141,7 +141,13 @@ class CoderRemoteConnectionHandle {
             port = 22
             authType = AuthType.OPEN_SSH
         }
-        val accessor = HighLevelHostAccessor.create(credentials, true)
+        val backgroundCredentials = RemoteCredentialsHolder().apply {
+            setHost(workspace.hostname)
+            userName = "coder"
+            port = 22
+            authType = AuthType.OPEN_SSH
+        }
+        val accessor = HighLevelHostAccessor.create(backgroundCredentials, true)
 
         // Deploy if we need to.
         val ideDir = this.deploy(workspace, accessor, indicator, timeout)

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -255,7 +255,7 @@ class CoderCLIManager(
         val startBlock = "# --- START CODER JETBRAINS $host"
         val endBlock = "# --- END CODER JETBRAINS $host"
         val isRemoving = workspaceNames.isEmpty()
-        val proxyArgs =
+        val baseArgs =
             listOfNotNull(
                 escape(localBinaryPath.toString()),
                 "--global-config",
@@ -265,8 +265,9 @@ class CoderCLIManager(
                 "ssh",
                 "--stdio",
                 if (settings.disableAutostart && feats.disableAutostart) "--disable-autostart" else null,
-                if (feats.reportWorkspaceUsage) "--usage-app=jetbrains" else null,
             )
+        val proxyArgs = baseArgs + listOfNotNull(if (feats.reportWorkspaceUsage) "--usage-app=jetbrains" else null)
+        val backgroundProxyArgs = baseArgs + listOfNotNull(if (feats.reportWorkspaceUsage) "--usage-app=disable" else null)
         val extraConfig =
             if (settings.sshConfigOptions.isNotBlank()) {
                 "\n" + settings.sshConfigOptions.prependIndent("  ")
@@ -293,7 +294,7 @@ class CoderCLIManager(
                         .plus(
                             """
                             Host ${getBackgroundHostName(deploymentURL, it)}
-                              ProxyCommand ${proxyArgs.joinToString(" ")} $it
+                              ProxyCommand ${backgroundProxyArgs.joinToString(" ")} $it
                               ConnectTimeout 0
                               StrictHostKeyChecking no
                               UserKnownHostsFile /dev/null

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -292,7 +292,7 @@ class CoderCLIManager(
                         .plus(
                             """
                             Host ${getBackgroundHostName(deploymentURL, it)}
-                              ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
+                              ProxyCommand ${proxyArgs.joinToString(" ")} $it
                               ConnectTimeout 0
                               StrictHostKeyChecking no
                               UserKnownHostsFile /dev/null
@@ -484,6 +484,13 @@ class CoderCLIManager(
             workspaceName: String,
         ): String {
             return getHostName(url, workspaceName) + "--bg"
+        }
+
+        @JvmStatic
+        fun getBackgroundHostName(
+            hostname: String,
+        ): String {
+            return hostname + "--bg"
         }
     }
 }

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -289,7 +289,6 @@ class CoderCLIManager(
                       SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                     """.trimIndent()
                         .plus(extraConfig)
-                        .plus(System.lineSeparator())
                         .plus(
                             """
                             Host ${getBackgroundHostName(deploymentURL, it)}
@@ -300,8 +299,8 @@ class CoderCLIManager(
                               LogLevel ERROR
                               SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                             """.trimIndent()
+                                .plus(extraConfig)
                         )
-                        .plus(extraConfig)
                         .replace("\n", System.lineSeparator())
                 },
             )

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -281,7 +281,15 @@ class CoderCLIManager(
                 transform = {
                     """
                     Host ${getHostName(deploymentURL, it)}
-                      ProxyCommand ${proxyArgs.joinToString(" ")} $it
+                      ProxyCommand CODER_SSH_USAGE_APP=jetbrains ${proxyArgs.joinToString(" ")} $it
+                      ConnectTimeout 0
+                      StrictHostKeyChecking no
+                      UserKnownHostsFile /dev/null
+                      LogLevel ERROR
+                      SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+
+                    Host ${getBackgroundHostName(deploymentURL, it)}
+                      ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
                       ConnectTimeout 0
                       StrictHostKeyChecking no
                       UserKnownHostsFile /dev/null
@@ -464,6 +472,14 @@ class CoderCLIManager(
             workspaceName: String,
         ): String {
             return "coder-jetbrains--$workspaceName--${url.safeHost()}"
+        }
+
+        @JvmStatic
+        fun getBackgroundHostName(
+            url: URL,
+            workspaceName: String,
+        ): String {
+            return getHostName(url, workspaceName) + "--bg"
         }
     }
 }

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -287,7 +287,6 @@ class CoderCLIManager(
                       UserKnownHostsFile /dev/null
                       LogLevel ERROR
                       SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-
                     Host ${getBackgroundHostName(deploymentURL, it)}
                       ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
                       ConnectTimeout 0

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -289,18 +289,19 @@ class CoderCLIManager(
                       SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                     """.trimIndent()
                         .plus(extraConfig)
+                        .plus(System.lineSeparator())
                         .plus(
-                        """
-                        Host ${getBackgroundHostName(deploymentURL, it)}
-                            ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
-                            ConnectTimeout 0
-                            StrictHostKeyChecking no
-                            UserKnownHostsFile /dev/null
-                            LogLevel ERROR
-                            SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-                        """.trimIndent()
-                            .plus(extraConfig)
+                            """
+                            Host ${getBackgroundHostName(deploymentURL, it)}
+                              ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
+                              ConnectTimeout 0
+                              StrictHostKeyChecking no
+                              UserKnownHostsFile /dev/null
+                              LogLevel ERROR
+                              SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+                            """.trimIndent()
                         )
+                        .plus(extraConfig)
                         .replace("\n", System.lineSeparator())
                 },
             )

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -289,6 +289,7 @@ class CoderCLIManager(
                       SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                     """.trimIndent()
                         .plus(extraConfig)
+                        .plus("\n")
                         .plus(
                             """
                             Host ${getBackgroundHostName(deploymentURL, it)}

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -287,15 +287,20 @@ class CoderCLIManager(
                       UserKnownHostsFile /dev/null
                       LogLevel ERROR
                       SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-                    Host ${getBackgroundHostName(deploymentURL, it)}
-                      ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
-                      ConnectTimeout 0
-                      StrictHostKeyChecking no
-                      UserKnownHostsFile /dev/null
-                      LogLevel ERROR
-                      SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                     """.trimIndent()
                         .plus(extraConfig)
+                        .plus(
+                        """
+                        Host ${getBackgroundHostName(deploymentURL, it)}
+                            ProxyCommand CODER_SSH_USAGE_APP=disable ${proxyArgs.joinToString(" ")} $it
+                            ConnectTimeout 0
+                            StrictHostKeyChecking no
+                            UserKnownHostsFile /dev/null
+                            LogLevel ERROR
+                            SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+                        """.trimIndent()
+                            .plus(extraConfig)
+                        )
                         .replace("\n", System.lineSeparator())
                 },
             )

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -281,7 +281,7 @@ class CoderCLIManager(
                 transform = {
                     """
                     Host ${getHostName(deploymentURL, it)}
-                      ProxyCommand CODER_SSH_USAGE_APP=jetbrains ${proxyArgs.joinToString(" ")} $it
+                      ProxyCommand ${proxyArgs.joinToString(" ")} $it
                       ConnectTimeout 0
                       StrictHostKeyChecking no
                       UserKnownHostsFile /dev/null
@@ -300,8 +300,7 @@ class CoderCLIManager(
                               SetEnv CODER_SSH_SESSION_TYPE=JetBrains
                             """.trimIndent()
                                 .plus(extraConfig)
-                        )
-                        .replace("\n", System.lineSeparator())
+                        ).replace("\n", System.lineSeparator())
                 },
             )
 

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceProjectIDEStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceProjectIDEStepView.kt
@@ -214,7 +214,7 @@ class CoderWorkspaceProjectIDEStepView(
                                     } else {
                                         IDECellRenderer(CoderGatewayBundle.message("gateway.connector.view.coder.connect-ssh"))
                                     }
-                                val executor = createRemoteExecutor(CoderCLIManager.getHostName(data.client.url, name))
+                                val executor = createRemoteExecutor(CoderCLIManager.getBackgroundHostName(data.client.url, name))
 
                                 if (ComponentValidator.getInstance(tfProject).isEmpty) {
                                     logger.info("Installing remote path validator...")

--- a/src/test/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/fixtures/outputs/append-blank-newlines.conf
@@ -4,14 +4,14 @@
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/fixtures/outputs/append-blank-newlines.conf
@@ -10,4 +10,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/append-blank.conf
+++ b/src/test/fixtures/outputs/append-blank.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-blank.conf
+++ b/src/test/fixtures/outputs/append-blank.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-blocks.conf
@@ -11,4 +11,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-blocks.conf
@@ -5,14 +5,14 @@ Host test2
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-newline.conf
+++ b/src/test/fixtures/outputs/append-no-newline.conf
@@ -4,14 +4,14 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-newline.conf
+++ b/src/test/fixtures/outputs/append-no-newline.conf
@@ -10,4 +10,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-related-blocks.conf
@@ -11,14 +11,14 @@ some jetbrains config
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-related-blocks.conf
@@ -17,4 +17,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/disable-autostart.conf
+++ b/src/test/fixtures/outputs/disable-autostart.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/disable-autostart.conf
+++ b/src/test/fixtures/outputs/disable-autostart.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--foo--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart foo
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/extra-config.conf
+++ b/src/test/fixtures/outputs/extra-config.conf
@@ -8,4 +8,13 @@ Host coder-jetbrains--extra--test.coder.invalid
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
   ServerAliveInterval 5
   ServerAliveCountMax 3
+Host coder-jetbrains--extra--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio extra
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+  ServerAliveInterval 5
+  ServerAliveCountMax 3
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/extra-config.conf
+++ b/src/test/fixtures/outputs/extra-config.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--extra--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio extra
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains extra
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
@@ -9,7 +9,7 @@ Host coder-jetbrains--extra--test.coder.invalid
   ServerAliveInterval 5
   ServerAliveCountMax 3
 Host coder-jetbrains--extra--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio extra
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable extra
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/header-command-windows.conf
+++ b/src/test/fixtures/outputs/header-command-windows.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--header--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--header--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio header
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/header-command-windows.conf
+++ b/src/test/fixtures/outputs/header-command-windows.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=jetbrains header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--header--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=disable header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/header-command.conf
+++ b/src/test/fixtures/outputs/header-command.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=jetbrains header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--header--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=disable header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/header-command.conf
+++ b/src/test/fixtures/outputs/header-command.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--header--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--header--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio header
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/fixtures/outputs/multiple-workspaces.conf
@@ -6,8 +6,22 @@ Host coder-jetbrains--foo--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid
   ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/fixtures/outputs/multiple-workspaces.conf
@@ -1,27 +1,27 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/no-disable-autostart.conf
+++ b/src/test/fixtures/outputs/no-disable-autostart.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--foo--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/no-report-usage.conf
+++ b/src/test/fixtures/outputs/no-report-usage.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/fixtures/outputs/replace-end-no-newline.conf
@@ -3,14 +3,14 @@ Host test
 Host test2
   Port 443 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/fixtures/outputs/replace-end-no-newline.conf
@@ -9,4 +9,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/replace-end.conf
+++ b/src/test/fixtures/outputs/replace-end.conf
@@ -4,14 +4,14 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-end.conf
+++ b/src/test/fixtures/outputs/replace-end.conf
@@ -10,4 +10,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -11,6 +11,13 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid
 Host test2
   Port 443

--- a/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -5,14 +5,14 @@ some coder config
 # ------------END-CODER------------
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-middle.conf
+++ b/src/test/fixtures/outputs/replace-middle.conf
@@ -8,6 +8,13 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid
 Host test2
   Port 443

--- a/src/test/fixtures/outputs/replace-middle.conf
+++ b/src/test/fixtures/outputs/replace-middle.conf
@@ -2,14 +2,14 @@ Host test
   Port 80
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-only.conf
+++ b/src/test/fixtures/outputs/replace-only.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-only.conf
+++ b/src/test/fixtures/outputs/replace-only.conf
@@ -6,4 +6,11 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/fixtures/outputs/replace-start.conf
+++ b/src/test/fixtures/outputs/replace-start.conf
@@ -6,6 +6,13 @@ Host coder-jetbrains--foo-bar--test.coder.invalid
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
+Host coder-jetbrains--foo-bar--test.coder.invalid--bg
+  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ConnectTimeout 0
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 # --- END CODER JETBRAINS test.coder.invalid
 Host test
   Port 80

--- a/src/test/fixtures/outputs/replace-start.conf
+++ b/src/test/fixtures/outputs/replace-start.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand CODER_SSH_USAGE_APP=disable /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/report-usage.conf
+++ b/src/test/fixtures/outputs/report-usage.conf
@@ -1,9 +1,0 @@
-# --- START CODER JETBRAINS test.coder.invalid
-Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo
-  ConnectTimeout 0
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-  LogLevel ERROR
-  SetEnv CODER_SSH_SESSION_TYPE=JetBrains
-# --- END CODER JETBRAINS test.coder.invalid

--- a/src/test/kotlin/com/coder/gateway/cli/CoderCLIManagerTest.kt
+++ b/src/test/kotlin/com/coder/gateway/cli/CoderCLIManagerTest.kt
@@ -313,19 +313,19 @@ internal class CoderCLIManagerTest {
             ).joinToString(System.lineSeparator())
         val tests =
             listOf(
-                SSHTest(listOf("foo", "bar"), null, "multiple-workspaces", "blank"),
-                SSHTest(listOf("foo", "bar"), null, "multiple-workspaces", "blank"),
-                SSHTest(listOf("foo-bar"), "blank", "append-blank", "blank"),
-                SSHTest(listOf("foo-bar"), "blank-newlines", "append-blank-newlines", "blank"),
-                SSHTest(listOf("foo-bar"), "existing-end", "replace-end", "no-blocks"),
-                SSHTest(listOf("foo-bar"), "existing-end-no-newline", "replace-end-no-newline", "no-blocks"),
-                SSHTest(listOf("foo-bar"), "existing-middle", "replace-middle", "no-blocks"),
-                SSHTest(listOf("foo-bar"), "existing-middle-and-unrelated", "replace-middle-ignore-unrelated", "no-related-blocks"),
-                SSHTest(listOf("foo-bar"), "existing-only", "replace-only", "blank"),
-                SSHTest(listOf("foo-bar"), "existing-start", "replace-start", "no-blocks"),
-                SSHTest(listOf("foo-bar"), "no-blocks", "append-no-blocks", "no-blocks"),
-                SSHTest(listOf("foo-bar"), "no-related-blocks", "append-no-related-blocks", "no-related-blocks"),
-                SSHTest(listOf("foo-bar"), "no-newline", "append-no-newline", "no-blocks"),
+                SSHTest(listOf("foo", "bar"), null, "multiple-workspaces", "blank", features = Features(false, true)),
+                SSHTest(listOf("foo", "bar"), null, "multiple-workspaces", "blank", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "blank", "append-blank", "blank", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "blank-newlines", "append-blank-newlines", "blank", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-end", "replace-end", "no-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-end-no-newline", "replace-end-no-newline", "no-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-middle", "replace-middle", "no-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-middle-and-unrelated", "replace-middle-ignore-unrelated", "no-related-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-only", "replace-only", "blank", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "existing-start", "replace-start", "no-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "no-blocks", "append-no-blocks", "no-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "no-related-blocks", "append-no-related-blocks", "no-related-blocks", features = Features(false, true)),
+                SSHTest(listOf("foo-bar"), "no-newline", "append-no-newline", "no-blocks", features = Features(false, true)),
                 if (getOS() == OS.WINDOWS) {
                     SSHTest(
                         listOf("header"),
@@ -333,6 +333,7 @@ internal class CoderCLIManagerTest {
                         "header-command-windows",
                         "blank",
                         """"C:\Program Files\My Header Command\HeaderCommand.exe" --url="%CODER_URL%" --test="foo bar"""",
+                        features = Features(false, true)
                     )
                 } else {
                     SSHTest(
@@ -341,17 +342,19 @@ internal class CoderCLIManagerTest {
                         "header-command",
                         "blank",
                         "my-header-command --url=\"\$CODER_URL\" --test=\"foo bar\" --literal='\$CODER_URL'",
+                        features = Features(false, true)
                     )
                 },
-                SSHTest(listOf("foo"), null, "disable-autostart", "blank", "", true, Features(true)),
-                SSHTest(listOf("foo"), null, "no-disable-autostart", "blank", "", true, Features(false)),
-                SSHTest(listOf("foo"), null, "report-usage", "blank", "", true, Features(false, true)),
+                SSHTest(listOf("foo"), null, "disable-autostart", "blank", "", true, Features(true, true)),
+                SSHTest(listOf("foo"), null, "no-disable-autostart", "blank", "", true, Features(false, true)),
+                SSHTest(listOf("foo"), null, "no-report-usage", "blank", "", true, Features(false, false)),
                 SSHTest(
                     listOf("extra"),
                     null,
                     "extra-config",
                     "blank",
                     extraConfig = extraConfig,
+                    features = Features(false, true)
                 ),
                 SSHTest(
                     listOf("extra"),
@@ -359,6 +362,7 @@ internal class CoderCLIManagerTest {
                     "extra-config",
                     "blank",
                     env = Environment(mapOf(CODER_SSH_CONFIG_OPTIONS to extraConfig)),
+                    features = Features(false, true)
                 ),
             )
 


### PR DESCRIPTION
This adds a new `getBackgroundHostName()` func that is intended to be used for all SSH connections that are not the main IDE connection. This prevents background admin actions using SSH to trigger usage tracking for the workspace. 