### PR TITLE
revise recent projects flow to be less confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## Unreleased
 
+- The "Recents" view has been updated to have a new flow.
+  Before, there were separate controls for managing the workspace and then you
+  could click a link to launch a project (clicking a link would also start a stopped workspace automatically).
+  Now, there are no workspace controls, just links which start the workspace automatically when needed.
+  The links are enabled when the workspace is STOPPED, CANCELED, FAILED, STARTING, RUNNING. These states represent
+  valid times to start a workspace and connect, or to simply connect to a running one or one that's already starting.
+  We also use a spinner icon when workspaces are in a transition state (STARTING, CANCELING, DELETING, STOPPING) 
+  to give context for why a link might be disabled or a connection might take longer than usual to establish.
+
 ## 2.13.1 - 2024-07-19
 
 ### Changed

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -7,6 +7,9 @@ import com.coder.gateway.models.WorkspaceProjectIDE
 import com.coder.gateway.models.toIdeWithStatus
 import com.coder.gateway.models.toRawString
 import com.coder.gateway.models.withWorkspaceProject
+import com.coder.gateway.sdk.CoderRestClient
+import com.coder.gateway.sdk.v2.models.Workspace
+import com.coder.gateway.sdk.v2.models.WorkspaceStatus
 import com.coder.gateway.services.CoderRecentWorkspaceConnectionsService
 import com.coder.gateway.services.CoderSettingsService
 import com.coder.gateway.util.SemVer
@@ -65,6 +68,7 @@ class CoderRemoteConnectionHandle {
     private val localTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
 
     fun connect(getParameters: (indicator: ProgressIndicator) -> WorkspaceProjectIDE) {
+
         val clientLifetime = LifetimeDefinition()
         clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title")) {
             try {

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -7,9 +7,6 @@ import com.coder.gateway.models.WorkspaceProjectIDE
 import com.coder.gateway.models.toIdeWithStatus
 import com.coder.gateway.models.toRawString
 import com.coder.gateway.models.withWorkspaceProject
-import com.coder.gateway.sdk.CoderRestClient
-import com.coder.gateway.sdk.v2.models.Workspace
-import com.coder.gateway.sdk.v2.models.WorkspaceStatus
 import com.coder.gateway.services.CoderRecentWorkspaceConnectionsService
 import com.coder.gateway.services.CoderSettingsService
 import com.coder.gateway.util.SemVer
@@ -68,7 +65,6 @@ class CoderRemoteConnectionHandle {
     private val localTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
 
     fun connect(getParameters: (indicator: ProgressIndicator) -> WorkspaceProjectIDE) {
-
         val clientLifetime = LifetimeDefinition()
         clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title")) {
             try {

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -282,7 +282,7 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                             row {
                                 // There must be a way to make this properly wrap?
                                 if (status.first == CoderIcons.PENDING) {
-                                    icon(status.first)
+                                    icon(AnimatedIcon.Default())
                                 }
                                 label("<html><body style='width:350px;'>" + status.third + "</html>").applyToComponent {
                                     foreground = status.second

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -176,10 +176,16 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                             if (deploymentError != null) {
                                 Triple(UIUtil.getErrorForeground(), deploymentError, UIUtil.getBalloonErrorIcon())
                             } else if (workspaceWithAgent != null) {
+                                val inLoadingState = listOf(WorkspaceStatus.STARTING, WorkspaceStatus.CANCELING, WorkspaceStatus.DELETING, WorkspaceStatus.STOPPING).contains(workspaceWithAgent?.workspace?.latestBuild?.status)
+
                                 Triple(
                                     workspaceWithAgent.status.statusColor(),
                                     workspaceWithAgent.status.description,
-                                    null,
+                                    if (inLoadingState) {
+                                        AnimatedIcon.Default()
+                                    } else {
+                                        null
+                                    },
                                 )
                             } else {
                                 Triple(UIUtil.getContextHelpForeground(), "Querying workspace status...", AnimatedIcon.Default())
@@ -203,14 +209,10 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                         }.topGap(gap)
 
                         val enableLinks = listOf(WorkspaceStatus.STOPPED, WorkspaceStatus.CANCELED, WorkspaceStatus.FAILED, WorkspaceStatus.STARTING, WorkspaceStatus.RUNNING).contains(workspaceWithAgent?.workspace?.latestBuild?.status)
-                        val inLoadingState = listOf(WorkspaceStatus.STARTING, WorkspaceStatus.CANCELING, WorkspaceStatus.DELETING, WorkspaceStatus.STOPPING).contains(workspaceWithAgent?.workspace?.latestBuild?.status)
 
                         // We only display an API error on the first workspace rather than duplicating it on each workspace.
                         if (deploymentError == null || showError) {
                             row {
-                                if (inLoadingState) {
-                                    icon(AnimatedIcon.Default())
-                                }
                                 if (status.third != null) {
                                     icon(status.third!!)
                                 }

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -174,15 +174,14 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                         val workspaceWithAgent = deployment?.items?.firstOrNull { it.workspace.name == workspaceName }
                         val status =
                             if (deploymentError != null) {
-                                Triple(UIUtil.getBalloonErrorIcon(), UIUtil.getErrorForeground(), deploymentError)
+                                Pair(UIUtil.getErrorForeground(), deploymentError)
                             } else if (workspaceWithAgent != null) {
-                                Triple(
-                                    workspaceWithAgent.status.icon,
+                                Pair(
                                     workspaceWithAgent.status.statusColor(),
                                     workspaceWithAgent.status.description,
                                 )
                             } else {
-                                Triple(AnimatedIcon.Default.INSTANCE, UIUtil.getContextHelpForeground(), "Querying workspace status...")
+                                Pair(UIUtil.getContextHelpForeground(), "Querying workspace status...")
                             }
                         val gap =
                             if (top) {
@@ -210,7 +209,9 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                                 if (inLoadingState) {
                                     icon(AnimatedIcon.Default())
                                 }
-                                label(workspaceWithAgent?.status?.description.orEmpty())
+                                label("<html><body style='width:350px;'>" + status.second + "</html>").applyToComponent {
+                                    foreground = status.first
+                                }
                             }
 
                             row {

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -213,8 +213,8 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                         // We only display an API error on the first workspace rather than duplicating it on each workspace.
                         if (deploymentError == null || showError) {
                             row {
-                                if (status.third != null) {
-                                    icon(status.third!!)
+                                status.third?.let {
+                                    icon(it)
                                 }
                                 label("<html><body style='width:350px;'>" + status.second + "</html>").applyToComponent {
                                     foreground = status.first

--- a/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderGatewayRecentWorkspaceConnectionsView.kt
@@ -179,7 +179,7 @@ class CoderGatewayRecentWorkspaceConnectionsView(private val setContentCallback:
                                 Triple(
                                     workspaceWithAgent.status.statusColor(),
                                     workspaceWithAgent.status.description,
-                                    null
+                                    null,
                                 )
                             } else {
                                 Triple(UIUtil.getContextHelpForeground(), "Querying workspace status...", AnimatedIcon.Default())


### PR DESCRIPTION
**Edit**: we changed the flow, links do show but are disabled if the workspace is in a non-starting pending state, and we started the workspace automatically negating the need to even have the manual controls

Previously recent workspaces had a status icon which looked a bit like a button to push, and the start workspace button could be confused as the cta to open a project.
Now the project links in recent projects only display once the workspace is running and ready to accept connections, and the confusing icon has been removed.

I think this flow is pretty clear, but people used to just clicking the link might freak out when they don't see their links or be frustrated they need to press two buttons.
An alternative option could be to remove the workspace start button entirely, since following a project link should start the workspace if required. 

https://github.com/user-attachments/assets/c9e2b47a-66be-4d19-80d2-e87b8d29f25d

