### PR TITLE
Set --url in SSH config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,24 @@
 
 ## Unreleased
 
+### Fixed
+
+- When the `CODER_URL` environment variable is set but you connect to a
+  different URL in Gateway, force the Coder CLI used in the SSH proxy command to
+  use the current URL instead of `CODER_URL`. This fixes connection issues such
+  as "failed to retrieve IDEs". To aply this fix, you must add the connection
+  again through the "Connect to Coder" flow or by using the dashboard link (the
+  recent connections do not reconfigure SSH).
+
+### Changed
+
 - The "Recents" view has been updated to have a new flow.
   Before, there were separate controls for managing the workspace and then you
   could click a link to launch a project (clicking a link would also start a stopped workspace automatically).
   Now, there are no workspace controls, just links which start the workspace automatically when needed.
   The links are enabled when the workspace is STOPPED, CANCELED, FAILED, STARTING, RUNNING. These states represent
   valid times to start a workspace and connect, or to simply connect to a running one or one that's already starting.
-  We also use a spinner icon when workspaces are in a transition state (STARTING, CANCELING, DELETING, STOPPING) 
+  We also use a spinner icon when workspaces are in a transition state (STARTING, CANCELING, DELETING, STOPPING)
   to give context for why a link might be disabled or a connection might take longer than usual to establish.
 
 ## 2.13.1 - 2024-07-19

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -256,6 +256,11 @@ class CoderCLIManager(
                 escape(localBinaryPath.toString()),
                 "--global-config",
                 escape(coderConfigPath.toString()),
+                // CODER_URL might be set, and it will override the URL file in
+                // the config directory, so override that here to make sure we
+                // always use the correct URL.
+                "--url",
+                escape(deploymentURL.toString()),
                 if (settings.headerCommand.isNotBlank()) "--header-command" else null,
                 if (settings.headerCommand.isNotBlank()) escapeSubcommand(settings.headerCommand) else null,
                 "ssh",

--- a/src/test/fixtures/outputs/append-blank-newlines.conf
+++ b/src/test/fixtures/outputs/append-blank-newlines.conf
@@ -4,14 +4,14 @@
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-blank.conf
+++ b/src/test/fixtures/outputs/append-blank.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-blocks.conf
@@ -5,14 +5,14 @@ Host test2
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-newline.conf
+++ b/src/test/fixtures/outputs/append-no-newline.conf
@@ -4,14 +4,14 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/append-no-related-blocks.conf
+++ b/src/test/fixtures/outputs/append-no-related-blocks.conf
@@ -11,14 +11,14 @@ some jetbrains config
 
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/disable-autostart.conf
+++ b/src/test/fixtures/outputs/disable-autostart.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart --usage-app=jetbrains foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --disable-autostart --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --disable-autostart --usage-app=disable foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --disable-autostart --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/extra-config.conf
+++ b/src/test/fixtures/outputs/extra-config.conf
@@ -1,6 +1,6 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--extra--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains extra
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains extra
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
@@ -9,7 +9,7 @@ Host coder-jetbrains--extra--test.coder.invalid
   ServerAliveInterval 5
   ServerAliveCountMax 3
 Host coder-jetbrains--extra--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable extra
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable extra
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/header-command-windows.conf
+++ b/src/test/fixtures/outputs/header-command-windows.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=jetbrains header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=jetbrains header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--header--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=disable header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid --header-command "\"C:\Program Files\My Header Command\HeaderCommand.exe\" --url=\"%%CODER_URL%%\" --test=\"foo bar\"" ssh --stdio --usage-app=disable header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/header-command.conf
+++ b/src/test/fixtures/outputs/header-command.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--header--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=jetbrains header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=jetbrains header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--header--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=disable header
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid --header-command 'my-header-command --url="$CODER_URL" --test="foo bar" --literal='\''$CODER_URL'\''' ssh --stdio --usage-app=disable header
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/log-dir.conf
+++ b/src/test/fixtures/outputs/log-dir.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --log-dir /tmp/coder-gateway/test.coder.invalid/logs --usage-app=jetbrains foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --log-dir /tmp/coder-gateway/test.coder.invalid/logs --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/multiple-workspaces.conf
+++ b/src/test/fixtures/outputs/multiple-workspaces.conf
@@ -1,27 +1,27 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/no-disable-autostart.conf
+++ b/src/test/fixtures/outputs/no-disable-autostart.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/no-report-usage.conf
+++ b/src/test/fixtures/outputs/no-report-usage.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio foo
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio foo
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-end-no-newline.conf
+++ b/src/test/fixtures/outputs/replace-end-no-newline.conf
@@ -3,14 +3,14 @@ Host test
 Host test2
   Port 443 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-end.conf
+++ b/src/test/fixtures/outputs/replace-end.conf
@@ -4,14 +4,14 @@ Host test2
   Port 443
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
+++ b/src/test/fixtures/outputs/replace-middle-ignore-unrelated.conf
@@ -5,14 +5,14 @@ some coder config
 # ------------END-CODER------------
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-middle.conf
+++ b/src/test/fixtures/outputs/replace-middle.conf
@@ -2,14 +2,14 @@ Host test
   Port 80
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-only.conf
+++ b/src/test/fixtures/outputs/replace-only.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null

--- a/src/test/fixtures/outputs/replace-start.conf
+++ b/src/test/fixtures/outputs/replace-start.conf
@@ -1,13 +1,13 @@
 # --- START CODER JETBRAINS test.coder.invalid
 Host coder-jetbrains--foo-bar--test.coder.invalid
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=jetbrains foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=jetbrains foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
   SetEnv CODER_SSH_SESSION_TYPE=JetBrains
 Host coder-jetbrains--foo-bar--test.coder.invalid--bg
-  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config ssh --stdio --usage-app=disable foo-bar
+  ProxyCommand /tmp/coder-gateway/test.coder.invalid/coder-linux-amd64 --global-config /tmp/coder-gateway/test.coder.invalid/config --url https://test.coder.invalid ssh --stdio --usage-app=disable foo-bar
   ConnectTimeout 0
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null


### PR DESCRIPTION
This fixes an issue where you have `CODER_URL` in your environment but then connect to a different URL.  The plugin will configure the settings file, but the cli will ignore it in favor of the environment variable.  The flag is always preferred, so setting that ensures we use the right URL.

Unit tests show it gets added at least, but sure would be nice if we could test the flow.  For now I manually set `CODER_URL` to something bogus when launching Gateway (like http://localhost:1234) then added a new connection as normal to dev.coder.com.