### PR TITLE
[toolbox] Add workspace actions

### DIFF
--- a/src/main/kotlin/com/coder/gateway/CoderRemoteProvider.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteProvider.kt
@@ -97,7 +97,7 @@ class CoderRemoteProvider(
                             it.name
                         }?.map { agent ->
                             // If we have an environment already, update that.
-                            val env = CoderRemoteEnvironment(client, ws, agent, observablePropertiesFactory)
+                            val env = CoderRemoteEnvironment(client, ws, agent, ui, observablePropertiesFactory)
                             lastEnvironments?.firstOrNull { it == env }?.let {
                                 it.update(ws, agent)
                                 it

--- a/src/main/kotlin/com/coder/gateway/models/WorkspaceAndAgentStatus.kt
+++ b/src/main/kotlin/com/coder/gateway/models/WorkspaceAndAgentStatus.kt
@@ -52,11 +52,8 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
      * Return the environment state for Toolbox, which tells it the label, color
      * and whether the environment is reachable.
      *
-     * We mark all ready and pending states as reachable since if the workspace
-     * is pending the cli will wait for it anyway.
-     *
-     * Additionally, terminal states like stopped are also marked as reachable,
-     * since the cli will start them.
+     * Note that a reachable environment will always display "connected" or
+     * "disconnected" regardless of the label we give that status.
      */
     fun toRemoteEnvironmentState(): CustomRemoteEnvironmentState {
         // Use comments; no named arguments for non-Kotlin functions.
@@ -67,7 +64,7 @@ enum class WorkspaceAndAgentStatus(val label: String, val description: String) {
             Color(104, 112, 128, 255), // lightThemeColor
             Color(224, 224, 240, 26), // darkThemeBackgroundColor
             Color(224, 224, 245, 250), // lightThemeBackgroundColor
-            ready() || pending() || canStart(), // reachable
+            ready(), // reachable
             // TODO@JB: How does this work?  Would like a spinner for pending states.
             null, // iconId
         )

--- a/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/models/Workspace.kt
@@ -18,4 +18,5 @@ data class Workspace(
     @Json(name = "latest_build") val latestBuild: WorkspaceBuild,
     @Json(name = "outdated") val outdated: Boolean,
     @Json(name = "name") val name: String,
+    @Json(name = "owner_name") val ownerName: String,
 )

--- a/src/main/kotlin/com/coder/gateway/views/CoderPage.kt
+++ b/src/main/kotlin/com/coder/gateway/views/CoderPage.kt
@@ -116,11 +116,13 @@ abstract class CoderPage(
  */
 class Action(
     private val label: String,
-    private val closesPage: Boolean,
+    private val closesPage: Boolean = false,
+    private val enabled: () -> Boolean = { true },
     private val cb: () -> Unit,
 ) : RunnableActionDescription {
     override fun getLabel(): String = label
     override fun getShouldClosePage(): Boolean = closesPage
+    override fun isEnabled(): Boolean = enabled()
     override fun run() {
         cb()
     }

--- a/src/test/kotlin/com/coder/gateway/sdk/DataGen.kt
+++ b/src/test/kotlin/com/coder/gateway/sdk/DataGen.kt
@@ -53,6 +53,7 @@ class DataGen {
                 ),
                 outdated = false,
                 name = name,
+                ownerName = "owner",
             )
         }
 


### PR DESCRIPTION
You can now start, stop, and update workspaces.  Since you can start workspaces yourself now, I marked non-ready states as unreachable, which prevents JetBrains from overriding with their own text ("disconnected" and "connected").  So now you will be able to see "stopped", "starting", and so on, which is nice.  For the ready states you will still see "disconnected" or "connected" unfortunately.  Ideally this would be displayed separately from the workspace state.  This also means you have two clicks instead of one to connect to a workspace, but I felt like it was worth the tradeoff to (mostly) see the actual workspace state, and it does match the current Gateway flow.  If we can separate the states visually then we can bring back the one-click behavior.

Weirdly, you can still press connect when environments are unreachable, but this will not actually work.  It does not actually even attempt to connect, because if it did the workspace would start via the cli, so it seems to just be a no-op.  Not sure what the idea here is, we may have to consult JetBrains.

Stacked on https://github.com/coder/jetbrains-coder/pull/487, for the CI fixes.

Closes https://github.com/coder/jetbrains-coder/issues/485