### PR TITLE
fix: use background ssh channel for link handler

### DIFF
--- a/src/main/kotlin/com/coder/gateway/util/LinkHandler.kt
+++ b/src/main/kotlin/com/coder/gateway/util/LinkHandler.kt
@@ -127,7 +127,7 @@ open class LinkHandler(
             verifyDownloadLink(parameters)
             WorkspaceProjectIDE.fromInputs(
                 name = CoderCLIManager.getWorkspaceParts(workspace, agent),
-                hostname = CoderCLIManager.getHostName(deploymentURL.toURL(), workspace, client.me, agent),
+                hostname = CoderCLIManager.getBackgroundHostName(deploymentURL.toURL(), workspace, client.me, agent),
                 projectPath = parameters.folder(),
                 ideProductCode = parameters.ideProductCode(),
                 ideBuildNumber = parameters.ideBuildNumber(),


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/15176

After some investigation into the interaction with the Jetbrains plugin and coder/coder I found a bug where 2 ssh sessions labeled with `jetbrains` for the usage app were being open. We only want to use the main hostname when we want to track user activity, so for any background processes we should be using the background hostname.