### PR TITLE
Start workspaces by shelling out to CLI

### DIFF
--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -451,6 +451,21 @@ class CoderCLIManager(
         return matches
     }
 
+    /**
+     * Start a workspace.
+     *
+     * Throws if the command execution fails.
+     */
+    fun startWorkspace(workspaceOwner: String, workspaceName: String): String {
+        return exec(
+            "--global-config",
+            coderConfigPath.toString(),
+            "start",
+            "--yes",
+            workspaceOwner+"/"+workspaceName,
+        )
+    }
+
     private fun exec(vararg args: String): String {
         val stdout =
             ProcessExecutor()

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderRestClient.kt
@@ -230,18 +230,6 @@ open class CoderRestClient(
     /**
      * @throws [APIResponseException].
      */
-    fun startWorkspace(workspace: Workspace): WorkspaceBuild {
-        val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.START)
-        val buildResponse = retroRestClient.createWorkspaceBuild(workspace.id, buildRequest).execute()
-        if (buildResponse.code() != HttpURLConnection.HTTP_CREATED) {
-            throw APIResponseException("start workspace ${workspace.name}", url, buildResponse)
-        }
-        return buildResponse.body()!!
-    }
-
-    /**
-     * @throws [APIResponseException].
-     */
     fun stopWorkspace(workspace: Workspace): WorkspaceBuild {
         val buildRequest = CreateWorkspaceBuildRequest(null, WorkspaceTransition.STOP)
         val buildResponse = retroRestClient.createWorkspaceBuild(workspace.id, buildRequest).execute()

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -303,13 +303,13 @@ class CoderWorkspacesStepView :
             CoderIcons.RUN,
         ) {
         override fun actionPerformed(p0: AnActionEvent) {
-            withoutNull(client, tableOfWorkspaces.selectedObject?.workspace) { c, workspace ->
+            withoutNull(cliManager, tableOfWorkspaces.selectedObject?.workspace) { cliManager, workspace ->
                 jobs[workspace.id]?.cancel()
                 jobs[workspace.id] =
                     cs.launch(ModalityState.current().asContextElement()) {
                         withContext(Dispatchers.IO) {
                             try {
-                                c.startWorkspace(workspace)
+                                cliManager.startWorkspace(workspace.ownerName, workspace.name)
                                 loadWorkspaces()
                             } catch (e: Exception) {
                                 logger.error("Could not start workspace ${workspace.name}", e)
@@ -659,7 +659,7 @@ class CoderWorkspacesStepView :
             cs.launch(ModalityState.current().asContextElement()) {
                 while (isActive) {
                     loadWorkspaces()
-                    delay(5000)
+                    delay(1000)
                 }
             }
     }


### PR DESCRIPTION
Replace the REST-API-based start flow with one that shells out to the coder CLI.

This is the JetBrains extension equivalent to https://github.com/coder/vscode-coder/pull/400.