### PR TITLE
Add "Check for IDE updates" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+- Added setting "Check for IDE updates" which controls whether the plugin
+  checks and prompts for available IDE backend updates.
+
 ## 2.16.0 - 2025-01-17
 
 ### Added

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -93,7 +93,7 @@ class CoderRemoteConnectionHandle {
                             },
                             true,
                         )
-                        if (attempt == 1) {
+                        if (settings.checkIDEUpdate && attempt == 1) {
                             // See if there is a newer (non-EAP) version of the IDE available.
                             checkUpdate(accessor, parameters, indicator)?.let { update ->
                                 // Store the old IDE to delete later.

--- a/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
@@ -157,6 +157,13 @@ class CoderSettingsConfigurable : BoundConfigurable("Coder") {
                             "Example format: CL 2023.3.6 233.15619.8",
                     )
             }
+            row(CoderGatewayBundle.message("gateway.connector.settings.check-ide-updates.heading")) {
+                checkBox(CoderGatewayBundle.message("gateway.connector.settings.check-ide-updates.title"))
+                    .bindSelected(state::checkIDEUpdates)
+                    .comment(
+                        CoderGatewayBundle.message("gateway.connector.settings.check-ide-updates.comment"),
+                    )
+            }.layout(RowLayout.PARENT_GRID)
         }
     }
 

--- a/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
+++ b/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
@@ -102,6 +102,8 @@ open class CoderSettingsState(
     open var workspaceFilter: String = "owner:me",
     // Default version of IDE to display in IDE selection dropdown
     open var defaultIde: String = "",
+    // Whether to check for IDE updates.
+    open var checkIDEUpdates: Boolean = true,
 )
 
 /**
@@ -181,6 +183,12 @@ open class CoderSettings(
      */
     val defaultIde: String
         get() = state.defaultIde
+
+    /**
+     * Whether to check for IDE updates.
+     */
+    val checkIDEUpdate: Boolean
+    get() = state.checkIDEUpdates
 
     /**
      * Whether to ignore a failed setup command.

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -139,3 +139,9 @@ gateway.connector.settings.workspace-filter.comment=The filter to apply when \
   which can be slow with many workspaces, and it adds every agent to the SSH \
   config, which can result in a large SSH config with many workspaces.
 gateway.connector.settings.default-ide=Default IDE Selection
+gateway.connector.settings.check-ide-updates.heading=IDE version check
+gateway.connector.settings.check-ide-updates.title=Check for IDE updates
+gateway.connector.settings.check-ide-updates.comment=Checking this box will \
+  cause the plugin to check for available IDE backend updates and prompt \
+  with an option to upgrade if a newer version is available.
+


### PR DESCRIPTION
This setting controls whether the plugin checks for available backend IDE upgrades (on by default). Turning it off suppresses the prompt to upgrade to a newer version.