### PR TITLE
Retrieve workspace directly in link handler when using wildcardSSH feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Changed
+
+Retrieve workspace directly in link handler when using wildcardSSH feature
+
 ## 2.19.0 - 2025-02-21
 
 ### Added

--- a/src/main/kotlin/com/coder/gateway/sdk/CoderRestClient.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/CoderRestClient.kt
@@ -177,6 +177,19 @@ open class CoderRestClient(
     }
 
     /**
+     * Retrieves a specific workspace by owner and name.
+     * @throws [APIResponseException].
+     */
+    fun workspaceByOwnerAndName(owner: String, workspaceName: String): Workspace {
+        val workspaceResponse = retroRestClient.workspaceByOwnerAndName(owner, workspaceName).execute()
+        if (!workspaceResponse.isSuccessful) {
+            throw APIResponseException("retrieve workspace", url, workspaceResponse)
+        }
+
+        return workspaceResponse.body()!!
+    }
+
+    /**
      * Retrieves all the agent names for all workspaces, including those that
      * are off.  Meant to be used when configuring SSH.
      */

--- a/src/main/kotlin/com/coder/gateway/sdk/v2/CoderV2RestFacade.kt
+++ b/src/main/kotlin/com/coder/gateway/sdk/v2/CoderV2RestFacade.kt
@@ -4,6 +4,7 @@ import com.coder.gateway.sdk.v2.models.BuildInfo
 import com.coder.gateway.sdk.v2.models.CreateWorkspaceBuildRequest
 import com.coder.gateway.sdk.v2.models.Template
 import com.coder.gateway.sdk.v2.models.User
+import com.coder.gateway.sdk.v2.models.Workspace
 import com.coder.gateway.sdk.v2.models.WorkspaceBuild
 import com.coder.gateway.sdk.v2.models.WorkspaceResource
 import com.coder.gateway.sdk.v2.models.WorkspacesResponse
@@ -21,6 +22,15 @@ interface CoderV2RestFacade {
      */
     @GET("api/v2/users/me")
     fun me(): Call<User>
+
+    /**
+     * Retrieves a specific workspace by owner and name.
+     */
+    @GET("api/v2/users/{user}/workspace/{workspace}")
+    fun workspaceByOwnerAndName(
+        @Path("user") user: String,
+        @Path("workspace") workspace: String,
+    ): Call<Workspace>
 
     /**
      * Retrieves all workspaces the authenticated user has access to.


### PR DESCRIPTION
Instead of listing all workspaces matching the filter, get info about the specific workspace the user is trying to connect to. This lets `jetbrains-gateway://` links to others' workspaces work without needing to modify the workspace filter parameter.