### PR TITLE
fix:  pass the folder parameter to the IDE&Project dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - installed EAP, RC, NIGHTLY and PREVIEW IDEs are no longer displayed if there is a higher released version available for download.
+- project path is prefilled with the `folder` URI parameter when the IDE&Project dialog opens for URI handling.
 
 ## 2.19.0 - 2025-02-21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginName=coder-gateway
 pluginVersion=2.20.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=233.6745
+pluginSinceBuild=243.26053
 # This should be kept up to date with the latest EAP. If the API is incompatible
 # with the latest stable, use the eap branch temporarily instead.
 pluginUntilBuild=251.*
@@ -26,11 +26,11 @@ pluginUntilBuild=251.*
 # that exists, ideally the most recent one, for example
 # 233.15325-EAP-CANDIDATE-SNAPSHOT).
 platformType=GW
-platformVersion=241.19416-EAP-CANDIDATE-SNAPSHOT
-instrumentationCompiler=243.15521-EAP-CANDIDATE-SNAPSHOT
+platformVersion=243.26053-EAP-CANDIDATE-SNAPSHOT
+instrumentationCompiler=243.26053-EAP-CANDIDATE-SNAPSHOT
 # Gateway does not have open sources.
 platformDownloadSources=true
-verifyVersions=2023.3,2024.1,2024.2,2024.3
+verifyVersions=2024.3,2025.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup=com.coder.gateway
 # Zip file name.
 pluginName=coder-gateway
 # SemVer format -> https://semver.org
-pluginVersion=2.20.0
+pluginVersion=2.20.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=243.26053

--- a/src/main/kotlin/com/coder/gateway/util/Dialogs.kt
+++ b/src/main/kotlin/com/coder/gateway/util/Dialogs.kt
@@ -38,7 +38,10 @@ private class CoderWorkspaceStepDialog(
 
     init {
         init()
-        title = CoderGatewayBundle.message("gateway.connector.view.coder.remoteproject.choose.text", CoderCLIManager.getWorkspaceParts(state.workspace, state.agent))
+        title = CoderGatewayBundle.message(
+            "gateway.connector.view.coder.remoteproject.choose.text",
+            CoderCLIManager.getWorkspaceParts(state.workspace, state.agent)
+        )
     }
 
     override fun show() {
@@ -75,12 +78,13 @@ fun askIDE(
     cli: CoderCLIManager,
     client: CoderRestClient,
     workspaces: List<Workspace>,
+    remoteProjectPath: String? = null
 ): WorkspaceProjectIDE? {
     var data: WorkspaceProjectIDE? = null
     ApplicationManager.getApplication().invokeAndWait {
         val dialog =
             CoderWorkspaceStepDialog(
-                CoderWorkspacesStepSelection(agent, workspace, cli, client, workspaces),
+                CoderWorkspacesStepSelection(agent, workspace, cli, client, workspaces, remoteProjectPath),
             )
         data = dialog.showAndGetData()
     }

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceProjectIDEStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspaceProjectIDEStepView.kt
@@ -95,7 +95,7 @@ private fun displayIdeWithStatus(ideWithStatus: IdeWithStatus): String =
  * to select an IDE and project to run on the workspace.
  */
 class CoderWorkspaceProjectIDEStepView(
-    private val showTitle: Boolean = true,
+    private val showTitle: Boolean = true
 ) : CoderWizardStep<WorkspaceProjectIDE>(
     CoderGatewayBundle.message("gateway.connector.view.coder.remoteproject.next.text"),
 ) {
@@ -200,7 +200,9 @@ class CoderWorkspaceProjectIDEStepView(
         val name = CoderCLIManager.getWorkspaceParts(data.workspace, data.agent)
         logger.info("Initializing workspace step for $name")
 
-        val homeDirectory = data.agent.expandedDirectory ?: data.agent.directory
+        val homeDirectory = data.remoteProjectPath.takeIf { !it.isNullOrBlank() }
+            ?: data.agent.expandedDirectory
+            ?: data.agent.directory
         tfProject.text = if (homeDirectory.isNullOrBlank()) "/home" else homeDirectory
         titleLabel.text = CoderGatewayBundle.message("gateway.connector.view.coder.remoteproject.choose.text", name)
         titleLabel.isVisible = showTitle
@@ -429,7 +431,7 @@ class CoderWorkspaceProjectIDEStepView(
         if (remainingInstalledIdes.size < installedIdes.size) {
             logger.info(
                 "Skipping the following list of installed IDEs because there is already a released version " +
-                    "available for download: ${(installedIdes - remainingInstalledIdes).joinToString { "${it.product.productCode} ${it.presentableVersion}" }}"
+                        "available for download: ${(installedIdes - remainingInstalledIdes).joinToString { "${it.product.productCode} ${it.presentableVersion}" }}"
             )
         }
         return remainingInstalledIdes.map { it.toIdeWithStatus() }.sorted() + availableIdes.map { it.toIdeWithStatus() }

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -105,6 +105,7 @@ data class CoderWorkspacesStepSelection(
     // Pass along the latest workspaces so we can configure the CLI a bit
     // faster, otherwise this step would have to fetch the workspaces again.
     val workspaces: List<Workspace>,
+    val remoteProjectPath: String? = null
 )
 
 /**
@@ -147,7 +148,8 @@ class CoderWorkspacesStepView :
             setEmptyState(CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.connect.text.disconnected"))
             setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
             selectionModel.addListSelectionListener {
-                nextButton.isEnabled = selectedObject?.status?.ready() == true && selectedObject?.agent?.operatingSystem == OS.LINUX
+                nextButton.isEnabled =
+                    selectedObject?.status?.ready() == true && selectedObject?.agent?.operatingSystem == OS.LINUX
                 if (selectedObject?.status?.ready() == true && selectedObject?.agent?.operatingSystem != OS.LINUX) {
                     notificationBanner.apply {
                         component.isVisible = true
@@ -343,22 +345,26 @@ class CoderWorkspacesStepView :
                                     val maxWait = Duration.ofMinutes(10)
                                     while (isActive) { // Wait for the workspace to fully stop.
                                         delay(timeout.toMillis())
-                                        val found = tableOfWorkspaces.items.firstOrNull { it.workspace.id == workspace.id }
+                                        val found =
+                                            tableOfWorkspaces.items.firstOrNull { it.workspace.id == workspace.id }
                                         when (val status = found?.workspace?.latestBuild?.status) {
                                             WorkspaceStatus.PENDING, WorkspaceStatus.STOPPING, WorkspaceStatus.RUNNING -> {
                                                 logger.info("Still waiting for ${workspace.name} to stop before updating")
                                             }
+
                                             WorkspaceStatus.STARTING, WorkspaceStatus.FAILED,
                                             WorkspaceStatus.CANCELING, WorkspaceStatus.CANCELED,
                                             WorkspaceStatus.DELETING, WorkspaceStatus.DELETED,
-                                            -> {
+                                                -> {
                                                 logger.warn("Canceled ${workspace.name} update due to status change to $status")
                                                 break
                                             }
+
                                             null -> {
                                                 logger.warn("Canceled ${workspace.name} update because it no longer exists")
                                                 break
                                             }
+
                                             WorkspaceStatus.STOPPED -> {
                                                 logger.info("${workspace.name} has stopped; updating now")
                                                 c.updateWorkspace(workspace)
@@ -560,7 +566,10 @@ class CoderWorkspacesStepView :
                 deploymentURL.host,
             )
         tableOfWorkspaces.setEmptyState(
-            CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.connect.text.connecting", deploymentURL.host),
+            CoderGatewayBundle.message(
+                "gateway.connector.view.coder.workspaces.connect.text.connecting",
+                deploymentURL.host
+            ),
         )
 
         tableOfWorkspaces.listTableModel.items = emptyList()
@@ -600,7 +609,10 @@ class CoderWorkspacesStepView :
                 client = authedClient
 
                 tableOfWorkspaces.setEmptyState(
-                    CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.connect.text.connected", deploymentURL.host),
+                    CoderGatewayBundle.message(
+                        "gateway.connector.view.coder.workspaces.connect.text.connected",
+                        deploymentURL.host
+                    ),
                 )
                 tfUrlComment?.text =
                     CoderGatewayBundle.message(
@@ -788,7 +800,8 @@ class WorkspacesTableModel :
         WorkspaceVersionColumnInfo("Version"),
         WorkspaceStatusColumnInfo("Status"),
     ) {
-    private class WorkspaceIconColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceIconColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(item: WorkspaceAgentListModel?): String? = item?.workspace?.templateName
 
         override fun getRenderer(item: WorkspaceAgentListModel?): TableCellRenderer {
@@ -820,7 +833,8 @@ class WorkspacesTableModel :
         }
     }
 
-    private class WorkspaceNameColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceNameColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(item: WorkspaceAgentListModel?): String? = item?.name
 
         override fun getComparator(): Comparator<WorkspaceAgentListModel> = Comparator { a, b ->
@@ -850,7 +864,8 @@ class WorkspacesTableModel :
         }
     }
 
-    private class WorkspaceOwnerColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceOwnerColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(item: WorkspaceAgentListModel?): String? = item?.workspace?.ownerName
 
         override fun getComparator(): Comparator<WorkspaceAgentListModel> = Comparator { a, b ->
@@ -880,7 +895,8 @@ class WorkspacesTableModel :
         }
     }
 
-    private class WorkspaceTemplateNameColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceTemplateNameColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(item: WorkspaceAgentListModel?): String? = item?.workspace?.templateName
 
         override fun getComparator(): java.util.Comparator<WorkspaceAgentListModel> = Comparator { a, b ->
@@ -909,7 +925,8 @@ class WorkspacesTableModel :
         }
     }
 
-    private class WorkspaceVersionColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceVersionColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(workspace: WorkspaceAgentListModel?): String? = if (workspace == null) {
             "Unknown"
         } else if (workspace.workspace.outdated) {
@@ -940,7 +957,8 @@ class WorkspacesTableModel :
         }
     }
 
-    private class WorkspaceStatusColumnInfo(columnName: String) : ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
+    private class WorkspaceStatusColumnInfo(columnName: String) :
+        ColumnInfo<WorkspaceAgentListModel, String>(columnName) {
         override fun valueOf(item: WorkspaceAgentListModel?): String? = item?.status?.label
 
         override fun getComparator(): java.util.Comparator<WorkspaceAgentListModel> = Comparator { a, b ->


### PR DESCRIPTION
 The value of the `folder` URI parameter is passed to the IDE&Project dialog when handling URIs. The folder value will be rendered instead of the default home folder if the value is not blank.

I've also changed the list of Gateway versions we run the verifier against to include Gateway 2025.1 while excluding some ancient releases.Without this commit the PR will fail to build, the declared snapshots are no longer available in the repository    
-resolves #466
