### PR TITLE
impl: verify cli signature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+### Added
+
+- support for checking if CLI is signed
+- improved progress reporting while downloading the CLI
+
 ## 2.21.1 - 2025-06-26
 
 ### Fixed

--- a/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderRemoteConnectionHandle.kt
@@ -66,7 +66,7 @@ class CoderRemoteConnectionHandle {
     private val localTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
     private val dialogUi = DialogUi(settings)
 
-    fun connect(getParameters: (indicator: ProgressIndicator) -> WorkspaceProjectIDE) {
+    fun connect(getParameters: suspend (indicator: ProgressIndicator) -> WorkspaceProjectIDE) {
         val clientLifetime = LifetimeDefinition()
         clientLifetime.launchUnderBackgroundProgress(CoderGatewayBundle.message("gateway.connector.coder.connection.provider.title")) {
             try {

--- a/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
@@ -68,6 +68,14 @@ class CoderSettingsConfigurable : BoundConfigurable("Coder") {
                         CoderGatewayBundle.message("gateway.connector.settings.enable-binary-directory-fallback.comment"),
                     )
             }.layout(RowLayout.PARENT_GRID)
+            row {
+                cell() // For alignment.
+                checkBox(CoderGatewayBundle.message("gateway.connector.settings.fallback-on-coder-for-signatures.title"))
+                    .bindSelected(state::fallbackOnCoderForSignatures)
+                    .comment(
+                        CoderGatewayBundle.message("gateway.connector.settings.fallback-on-coder-for-signatures.comment"),
+                    )
+            }.layout(RowLayout.PARENT_GRID)
             row(CoderGatewayBundle.message("gateway.connector.settings.header-command.title")) {
                 textField().resizableColumn().align(AlignX.FILL)
                     .bindText(state::headerCommand)

--- a/src/main/kotlin/com/coder/gateway/cli/downloader/CoderDownloadApi.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/downloader/CoderDownloadApi.kt
@@ -1,0 +1,29 @@
+package com.coder.gateway.cli.downloader
+
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.HeaderMap
+import retrofit2.http.Streaming
+import retrofit2.http.Url
+
+/**
+ * Retrofit API for downloading CLI
+ */
+interface CoderDownloadApi {
+    @GET
+    @Streaming
+    suspend fun downloadCli(
+        @Url url: String,
+        @Header("If-None-Match") eTag: String? = null,
+        @HeaderMap headers: Map<String, String> = emptyMap(),
+        @Header("Accept-Encoding") acceptEncoding: String = "gzip",
+    ): Response<ResponseBody>
+
+    @GET
+    suspend fun downloadSignature(
+        @Url url: String,
+        @HeaderMap headers: Map<String, String> = emptyMap()
+    ): Response<ResponseBody>
+}

--- a/src/main/kotlin/com/coder/gateway/cli/downloader/CoderDownloadService.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/downloader/CoderDownloadService.kt
@@ -1,0 +1,238 @@
+package com.coder.gateway.cli.downloader
+
+import com.coder.gateway.cli.ex.ResponseException
+import com.coder.gateway.settings.CoderSettings
+import com.coder.gateway.util.OS
+import com.coder.gateway.util.SemVer
+import com.coder.gateway.util.getHeaders
+import com.coder.gateway.util.getOS
+import com.coder.gateway.util.sha1
+import com.intellij.openapi.diagnostic.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.ResponseBody
+import retrofit2.Response
+import java.io.FileInputStream
+import java.net.HttpURLConnection.HTTP_NOT_FOUND
+import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
+import java.net.HttpURLConnection.HTTP_OK
+import java.net.URI
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.util.zip.GZIPInputStream
+import kotlin.io.path.name
+import kotlin.io.path.notExists
+
+/**
+ * Handles the download steps of Coder CLI
+ */
+class CoderDownloadService(
+    private val settings: CoderSettings,
+    private val downloadApi: CoderDownloadApi,
+    private val deploymentUrl: URL,
+    forceDownloadToData: Boolean,
+) {
+    private val remoteBinaryURL: URL = settings.binSource(deploymentUrl)
+    private val cliFinalDst: Path = settings.binPath(deploymentUrl, forceDownloadToData)
+    private val cliTempDst: Path = cliFinalDst.resolveSibling("${cliFinalDst.name}.tmp")
+
+    suspend fun downloadCli(buildVersion: String, showTextProgress: ((t: String) -> Unit)? = null): DownloadResult {
+        val eTag = calculateLocalETag()
+        if (eTag != null) {
+            logger.info("Found existing binary at $cliFinalDst; calculated hash as $eTag")
+        }
+        val response = downloadApi.downloadCli(
+            url = remoteBinaryURL.toString(),
+            eTag = eTag?.let { "\"$it\"" },
+            headers = getRequestHeaders()
+        )
+
+        return when (response.code()) {
+            HTTP_OK -> {
+                logger.info("Downloading binary to temporary $cliTempDst")
+                response.saveToDisk(cliTempDst, showTextProgress, buildVersion)?.makeExecutable()
+                DownloadResult.Downloaded(remoteBinaryURL, cliTempDst)
+            }
+
+            HTTP_NOT_MODIFIED -> {
+                logger.info("Using cached binary at $cliFinalDst")
+                showTextProgress?.invoke("Using cached binary")
+                DownloadResult.Skipped
+            }
+
+            else -> {
+                throw ResponseException(
+                    "Unexpected response from $remoteBinaryURL",
+                    response.code()
+                )
+            }
+        }
+    }
+
+    /**
+     * Renames the temporary binary file to its original destination name.
+     * The implementation will override sibling file that has the original
+     * destination name.
+     */
+    suspend fun commit(): Path {
+        return withContext(Dispatchers.IO) {
+            logger.info("Renaming binary from $cliTempDst to $cliFinalDst")
+            Files.move(cliTempDst, cliFinalDst, StandardCopyOption.REPLACE_EXISTING)
+            cliFinalDst.makeExecutable()
+            cliFinalDst
+        }
+    }
+
+    /**
+     * Cleans up the temporary binary file if it exists.
+     */
+    suspend fun cleanup() {
+        withContext(Dispatchers.IO) {
+            runCatching { Files.deleteIfExists(cliTempDst) }
+                .onFailure { ex ->
+                    logger.warn("Failed to delete temporary CLI file: $cliTempDst", ex)
+                }
+        }
+    }
+
+    private fun calculateLocalETag(): String? {
+        return try {
+            if (cliFinalDst.notExists()) {
+                return null
+            }
+            sha1(FileInputStream(cliFinalDst.toFile()))
+        } catch (e: Exception) {
+            logger.warn("Unable to calculate hash for $cliFinalDst", e)
+            null
+        }
+    }
+
+    private fun getRequestHeaders(): Map<String, String> {
+        return if (settings.headerCommand.isBlank()) {
+            emptyMap()
+        } else {
+            getHeaders(deploymentUrl, settings.headerCommand)
+        }
+    }
+
+    private fun Response<ResponseBody>.saveToDisk(
+        localPath: Path,
+        showTextProgress: ((t: String) -> Unit)? = null,
+        buildVersion: String? = null
+    ): Path? {
+        val responseBody = this.body() ?: return null
+        Files.deleteIfExists(localPath)
+        Files.createDirectories(localPath.parent)
+
+        val outputStream = Files.newOutputStream(
+            localPath,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING
+        )
+        val contentEncoding = this.headers()["Content-Encoding"]
+        val sourceStream = if (contentEncoding?.contains("gzip", ignoreCase = true) == true) {
+            GZIPInputStream(responseBody.byteStream())
+        } else {
+            responseBody.byteStream()
+        }
+
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var bytesRead: Int
+        var totalRead = 0L
+        // local path is a temporary filename, reporting the progress with the real name
+        val binaryName = localPath.name.removeSuffix(".tmp")
+        sourceStream.use { source ->
+            outputStream.use { sink ->
+                while (source.read(buffer).also { bytesRead = it } != -1) {
+                    sink.write(buffer, 0, bytesRead)
+                    totalRead += bytesRead
+                    val prettyBuildVersion = buildVersion ?: ""
+                    showTextProgress?.invoke(
+                        "$binaryName $prettyBuildVersion - ${totalRead.toHumanReadableSize()} downloaded"
+                    )
+                }
+            }
+        }
+        return cliFinalDst
+    }
+
+
+    private fun Path.makeExecutable() {
+        if (getOS() != OS.WINDOWS) {
+            logger.info("Making $this executable...")
+            this.toFile().setExecutable(true)
+        }
+    }
+
+    private fun Long.toHumanReadableSize(): String {
+        if (this < 1024) return "$this B"
+
+        val kb = this / 1024.0
+        if (kb < 1024) return String.format("%.1f KB", kb)
+
+        val mb = kb / 1024.0
+        if (mb < 1024) return String.format("%.1f MB", mb)
+
+        val gb = mb / 1024.0
+        return String.format("%.1f GB", gb)
+    }
+
+    suspend fun downloadSignature(showTextProgress: ((t: String) -> Unit)? = null): DownloadResult {
+        return downloadSignature(remoteBinaryURL, showTextProgress, getRequestHeaders())
+    }
+
+    private suspend fun downloadSignature(
+        url: URL,
+        showTextProgress: ((t: String) -> Unit)? = null,
+        headers: Map<String, String> = emptyMap()
+    ): DownloadResult {
+        val signatureURL = url.toURI().resolve(settings.defaultSignatureNameByOsAndArch).toURL()
+        val localSignaturePath = cliFinalDst.parent.resolve(settings.defaultSignatureNameByOsAndArch)
+        logger.info("Downloading signature from $signatureURL")
+
+        val response = downloadApi.downloadSignature(
+            url = signatureURL.toString(),
+            headers = headers
+        )
+
+        return when (response.code()) {
+            HTTP_OK -> {
+                response.saveToDisk(localSignaturePath, showTextProgress)
+                DownloadResult.Downloaded(signatureURL, localSignaturePath)
+            }
+
+            HTTP_NOT_FOUND -> {
+                logger.warn("Signature file not found at $signatureURL")
+                DownloadResult.NotFound
+            }
+
+            else -> {
+                DownloadResult.Failed(
+                    ResponseException(
+                        "Failed to download signature from $signatureURL",
+                        response.code()
+                    )
+                )
+            }
+        }
+
+    }
+
+    suspend fun downloadReleasesSignature(
+        buildVersion: String,
+        showTextProgress: ((t: String) -> Unit)? = null
+    ): DownloadResult {
+        val semVer = SemVer.parse(buildVersion)
+        return downloadSignature(
+            URI.create("https://releases.coder.com/coder-cli/${semVer.major}.${semVer.minor}.${semVer.patch}/").toURL(),
+            showTextProgress
+        )
+    }
+
+    companion object {
+        val logger = Logger.getInstance(CoderDownloadService::class.java.simpleName)
+    }
+}

--- a/src/main/kotlin/com/coder/gateway/cli/downloader/DownloadResult.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/downloader/DownloadResult.kt
@@ -1,0 +1,23 @@
+package com.coder.gateway.cli.downloader
+
+import java.net.URL
+import java.nio.file.Path
+
+
+/**
+ * Result of a download operation
+ */
+sealed class DownloadResult {
+    object Skipped : DownloadResult()
+    object NotFound : DownloadResult()
+    data class Downloaded(val source: URL, val dst: Path) : DownloadResult()
+    data class Failed(val error: Exception) : DownloadResult()
+
+    fun isSkipped(): Boolean = this is Skipped
+
+    fun isNotFound(): Boolean = this is NotFound
+
+    fun isFailed(): Boolean = this is Failed
+
+    fun isNotDownloaded(): Boolean = this !is Downloaded
+}

--- a/src/main/kotlin/com/coder/gateway/cli/ex/Exceptions.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/ex/Exceptions.kt
@@ -5,3 +5,5 @@ class ResponseException(message: String, val code: Int) : Exception(message)
 class SSHConfigFormatException(message: String) : Exception(message)
 
 class MissingVersionException(message: String) : Exception(message)
+
+class UnsignedBinaryExecutionDeniedException(message: String?) : Exception(message)

--- a/src/main/kotlin/com/coder/gateway/cli/gpg/GPGVerifier.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/gpg/GPGVerifier.kt
@@ -1,0 +1,142 @@
+package com.coder.gateway.cli.gpg
+
+import com.coder.gateway.settings.CoderSettings
+import com.coder.gateway.cli.gpg.VerificationResult.Failed
+import com.coder.gateway.cli.gpg.VerificationResult.Invalid
+import com.coder.gateway.cli.gpg.VerificationResult.SignatureNotFound
+import com.coder.gateway.cli.gpg.VerificationResult.Valid
+import com.intellij.openapi.diagnostic.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bouncycastle.bcpg.ArmoredInputStream
+import org.bouncycastle.openpgp.PGPException
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.bouncycastle.openpgp.PGPPublicKeyRing
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+import org.bouncycastle.openpgp.PGPSignatureList
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentVerifierBuilderProvider
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.inputStream
+
+class GPGVerifier(
+    private val settings: CoderSettings
+) {
+
+    suspend fun verifySignature(
+        cli: Path,
+        signature: Path,
+    ): VerificationResult {
+        return try {
+            if (!Files.exists(signature)) {
+                logger.warn("Signature file not found, skipping verification")
+                return SignatureNotFound
+            }
+
+            val (signatureBytes, publicKeyRing) = withContext(Dispatchers.IO) {
+                val signatureBytes = Files.readAllBytes(signature)
+                val publicKeyRing = getCoderPublicKeyRings()
+
+                Pair(signatureBytes, publicKeyRing)
+            }
+            return verifyDetachedSignature(
+                cliPath = cli,
+                signatureBytes = signatureBytes,
+                publicKeyRings = publicKeyRing
+            )
+        } catch (e: Exception) {
+            logger.error("GPG signature verification failed", e)
+            Failed(e)
+        }
+    }
+
+    private fun getCoderPublicKeyRings(): List<PGPPublicKeyRing> {
+        try {
+            val coderPublicKey = javaClass.getResourceAsStream("/META-INF/trusted-keys/pgp-public.key")
+                ?.readAllBytes() ?: throw IllegalStateException("Trusted public key not found")
+            return loadPublicKeyRings(coderPublicKey)
+        } catch (e: Exception) {
+            throw PGPException("Failed to load Coder public GPG key", e)
+        }
+    }
+
+    /**
+     * Load public key rings from bytes
+     */
+    fun loadPublicKeyRings(publicKeyBytes: ByteArray): List<PGPPublicKeyRing> {
+        return try {
+            val keyInputStream = ArmoredInputStream(ByteArrayInputStream(publicKeyBytes))
+            val keyRingCollection = PGPPublicKeyRingCollection(
+                PGPUtil.getDecoderStream(keyInputStream),
+                JcaKeyFingerprintCalculator()
+            )
+            keyRingCollection.keyRings.asSequence().toList()
+        } catch (e: Exception) {
+            throw PGPException("Failed to load public key ring", e)
+        }
+    }
+
+    /**
+     * Verify a detached GPG signature
+     */
+    fun verifyDetachedSignature(
+        cliPath: Path,
+        signatureBytes: ByteArray,
+        publicKeyRings: List<PGPPublicKeyRing>
+    ): VerificationResult {
+        try {
+            val signatureInputStream = ArmoredInputStream(ByteArrayInputStream(signatureBytes))
+            val pgpObjectFactory = JcaPGPObjectFactory(signatureInputStream)
+            val signatureList = pgpObjectFactory.nextObject() as? PGPSignatureList
+                ?: throw PGPException("Invalid signature format")
+
+            if (signatureList.isEmpty) {
+                return Invalid("No signatures found in signature file")
+            }
+
+            val signature = signatureList[0]
+            val publicKey = findPublicKey(publicKeyRings, signature.keyID)
+                ?: throw PGPException("Public key not found for signature")
+
+            signature.init(JcaPGPContentVerifierBuilderProvider(), publicKey)
+            cliPath.inputStream().use { fileStream ->
+                val buffer = ByteArray(8192)
+                var bytesRead: Int
+                while (fileStream.read(buffer).also { bytesRead = it } != -1) {
+                    signature.update(buffer, 0, bytesRead)
+                }
+            }
+
+            val isValid = signature.verify()
+            logger.info("GPG signature verification result: $isValid")
+            if (isValid) {
+                return Valid
+            }
+            return Invalid()
+        } catch (e: Exception) {
+            logger.error("GPG signature verification failed", e)
+            return Failed(e)
+        }
+    }
+
+    /**
+     * Find a public key across all key rings in the collection
+     */
+    private fun findPublicKey(
+        keyRings: List<PGPPublicKeyRing>,
+        keyId: Long
+    ): PGPPublicKey? {
+        keyRings.forEach { keyRing ->
+            keyRing.getPublicKey(keyId)?.let { return it }
+        }
+        return null
+    }
+
+    companion object {
+        val logger = Logger.getInstance(GPGVerifier::class.java.simpleName)
+    }
+}

--- a/src/main/kotlin/com/coder/gateway/cli/gpg/VerificationResult.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/gpg/VerificationResult.kt
@@ -1,0 +1,15 @@
+package com.coder.gateway.cli.gpg
+
+/**
+ * Result of signature verification
+ */
+sealed class VerificationResult {
+    object Valid : VerificationResult()
+    data class Invalid(val reason: String? = null) : VerificationResult()
+    data class Failed(val error: Exception) : VerificationResult()
+    object SignatureNotFound : VerificationResult()
+
+    fun isValid(): Boolean = this == Valid
+    fun isInvalid(): Boolean = this is Invalid
+    fun signatureIsNotFound(): Boolean = this == SignatureNotFound
+}

--- a/src/main/kotlin/com/coder/gateway/util/LinkHandler.kt
+++ b/src/main/kotlin/com/coder/gateway/util/LinkHandler.kt
@@ -28,7 +28,7 @@ open class LinkHandler(
      * Throw if required arguments are not supplied or the workspace is not in a
      * connectable state.
      */
-    fun handle(
+    suspend fun handle(
         parameters: Map<String, String>,
         indicator: ((t: String) -> Unit)? = null,
     ): WorkspaceProjectIDE {

--- a/src/main/kotlin/com/coder/gateway/util/SemVer.kt
+++ b/src/main/kotlin/com/coder/gateway/util/SemVer.kt
@@ -1,6 +1,6 @@
 package com.coder.gateway.util
 
-class SemVer(private val major: Long = 0, private val minor: Long = 0, private val patch: Long = 0) : Comparable<SemVer> {
+class SemVer(val major: Long = 0, val minor: Long = 0, val patch: Long = 0) : Comparable<SemVer> {
     init {
         require(major >= 0) { "Coder major version must be a positive number" }
         require(minor >= 0) { "Coder minor version must be a positive number" }

--- a/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
+++ b/src/main/kotlin/com/coder/gateway/views/steps/CoderWorkspacesStepView.kt
@@ -14,6 +14,7 @@ import com.coder.gateway.sdk.v2.models.WorkspaceStatus
 import com.coder.gateway.sdk.v2.models.toAgentList
 import com.coder.gateway.services.CoderRestClientService
 import com.coder.gateway.services.CoderSettingsService
+import com.coder.gateway.services.CoderSettingsStateService
 import com.coder.gateway.settings.Source
 import com.coder.gateway.util.DialogUi
 import com.coder.gateway.util.InvalidVersionException
@@ -40,6 +41,7 @@ import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.ui.AnActionButton
 import com.intellij.ui.RelativeFont
 import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.BottomGap
@@ -116,6 +118,7 @@ class CoderWorkspacesStepView :
     CoderWizardStep<CoderWorkspacesStepSelection>(
         CoderGatewayBundle.message("gateway.connector.view.coder.workspaces.next.text"),
     ) {
+    private val state: CoderSettingsStateService = service()
     private val settings: CoderSettingsService = service<CoderSettingsService>()
     private val dialogUi = DialogUi(settings)
     private val cs = CoroutineScope(Dispatchers.Main)
@@ -130,6 +133,7 @@ class CoderWorkspacesStepView :
     private var tfUrl: JTextField? = null
     private var tfUrlComment: JLabel? = null
     private var cbExistingToken: JCheckBox? = null
+    private var cbFallbackOnSignature: JCheckBox? = null
 
     private val notificationBanner = NotificationBanner()
     private var tableOfWorkspaces =
@@ -262,6 +266,19 @@ class CoderWorkspacesStepView :
                     )
                 }.layout(RowLayout.PARENT_GRID)
             }
+            row {
+                cell() // For alignment.
+                    checkBox(CoderGatewayBundle.message("gateway.connector.settings.fallback-on-coder-for-signatures.title"))
+                        .bindSelected(state::fallbackOnCoderForSignatures).applyToComponent {
+                            addActionListener { event ->
+                                state.fallbackOnCoderForSignatures = (event.source as JBCheckBox).isSelected
+                            }
+                        }
+                        .comment(
+                            CoderGatewayBundle.message("gateway.connector.settings.fallback-on-coder-for-signatures.comment"),
+                        )
+
+            }.layout(RowLayout.PARENT_GRID)
             row {
                 scrollCell(
                     toolbar.createPanel().apply {

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -75,6 +75,10 @@ gateway.connector.settings.enable-binary-directory-fallback.title=Fall back to d
 gateway.connector.settings.enable-binary-directory-fallback.comment=Checking this \
   box will allow the plugin to fall back to the data directory when the CLI \
   directory is not writable.
+
+gateway.connector.settings.fallback-on-coder-for-signatures.title=Fall back on releases.coder.com for signatures
+gateway.connector.settings.fallback-on-coder-for-signatures.comment=Verify binary signature using releases.coder.com when CLI signatures are not available from the deployment
+
 gateway.connector.settings.header-command.title=Header command
 gateway.connector.settings.header-command.comment=An external command that \
   outputs additional HTTP headers added to all requests. The command must \


### PR DESCRIPTION
This PR introduces support for verifying the CLI binary using a detached PGP signature. Starting with version 2.24, Coder signs all CLI binaries. For clients using older versions or running Gateway in air-gapped environments, unsigned CLIs can still be executed — but users will have to confirm it each time.

In terms of code changes - the PR includes a big refactor around CLI downloading with most of the code refactored and extracted in various components that provide clean steps and result state in the main download method. Then the pgp verification logic was added on top, with some particularities:
- the pgp public key is embedded in the plugin as a jar resource
- we support multiple key rings in the public key
- the user has the option of running the CLI if no signature was found
- the signature search has a fallback approach: first we look in the Coder deployment, and then fall back to releases.coder.com to search for the signature if the user allows it.
- we expect the signature to be under the same relative path as the CLI (we have an option which allows user to pick the CLI from  a different source other than the Coder deployment)
- improved progress reporting while downloading the cli and the signatures

This PR is a backport of https://github.com/coder/coder-jetbrains-toolbox/pull/148