### PR TITLE
fix: don't create new api keys each time we do workspace polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- api keys are no longer created each time workspaces are polled
+
 ## 2.22.1 - 2025-07-30
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup=com.coder.gateway
 artifactName=coder-gateway
 pluginName=Coder
 # SemVer format -> https://semver.org
-pluginVersion=2.22.1
+pluginVersion=2.22.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=243.26574

--- a/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
+++ b/src/main/kotlin/com/coder/gateway/cli/CoderCLIManager.kt
@@ -288,6 +288,7 @@ class CoderCLIManager(
         return exec(
             "login",
             deploymentURL.toString(),
+            "--use-token-as-session",
             "--token",
             token,
             "--global-config",


### PR DESCRIPTION
The default behavior for `coder login --token <token>` is to:
- use the provided token temporarily to authenticate the login process
- generate a new session token and stores that for future CLI use
- the original token provided is not stored or reused

The Coder `Recent projects` view polls every 5 seconds for workspaces from  multiple Coder deployment. The polling process also involves a call to the `cli.login`. The cli is later used start workspaces if user clicks on a project for which the workspace is stopped. Instead of generating a new token each time we login we can use the `coder login --use-token-as-session --token <token>` which:
- uses the provided token directly as the session token
- stores the original token for future CLI commands
- no new token is generated

Additionally the login can be called on demand, only when a "recent" project is stopped and the user wants to start it. This PR reduces a lot of overhead associated with spawning cli commands every 5 seconds.

- resolves #567
