### PR TITLE
impl: fall back to CODER_HEADER_COMMAND when the header command setting is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Added
+
+- the header command falls back to the `CODER_HEADER_COMMAND` environment variable when the setting is blank, matching the Coder CLI and the VS Code extension
+
 ## 2.23.1 - 2026-01-21
 
 ### Changed

--- a/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
+++ b/src/main/kotlin/com/coder/gateway/CoderSettingsConfigurable.kt
@@ -2,6 +2,7 @@ package com.coder.gateway
 
 import com.coder.gateway.services.CoderSettingsService
 import com.coder.gateway.services.CoderSettingsStateService
+import com.coder.gateway.settings.CODER_HEADER_COMMAND
 import com.coder.gateway.settings.CODER_SSH_CONFIG_OPTIONS
 import com.coder.gateway.util.canCreateDirectory
 import com.intellij.openapi.components.service
@@ -89,7 +90,10 @@ class CoderSettingsConfigurable : BoundConfigurable("Coder") {
                 textField().resizableColumn().align(AlignX.FILL)
                     .bindText(state::headerCommand)
                     .comment(
-                        CoderGatewayBundle.message("gateway.connector.settings.header-command.comment"),
+                        CoderGatewayBundle.message(
+                            "gateway.connector.settings.header-command.comment",
+                            CODER_HEADER_COMMAND,
+                        ),
                     )
             }.layout(RowLayout.PARENT_GRID)
             row(CoderGatewayBundle.message("gateway.connector.settings.tls-cert-path.title")) {

--- a/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
+++ b/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
@@ -77,9 +77,8 @@ open class CoderSettingsState(
 
     // An external command that outputs additional HTTP headers added to all
     // requests. The command must output each header as `key=value` on its own
-    // line. The following environment variables will be available to the
-    // process: CODER_URL. If blank, the CODER_HEADER_COMMAND environment
-    // variable is used, if set.
+    // line. When this setting is blank, the CODER_HEADER_COMMAND environment
+    // variable is used instead, if set.
     open var headerCommand: String = "",
     // Optionally set this to the path of a certificate to use for TLS
     // connections. The certificate should be in X.509 PEM format.

--- a/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
+++ b/src/main/kotlin/com/coder/gateway/settings/CoderSettings.kt
@@ -14,6 +14,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
+const val CODER_HEADER_COMMAND = "CODER_HEADER_COMMAND"
 const val CODER_SSH_CONFIG_OPTIONS = "CODER_SSH_CONFIG_OPTIONS"
 const val CODER_URL = "CODER_URL"
 
@@ -77,7 +78,8 @@ open class CoderSettingsState(
     // An external command that outputs additional HTTP headers added to all
     // requests. The command must output each header as `key=value` on its own
     // line. The following environment variables will be available to the
-    // process: CODER_URL.
+    // process: CODER_URL. If blank, the CODER_HEADER_COMMAND environment
+    // variable is used, if set.
     open var headerCommand: String = "",
     // Optionally set this to the path of a certificate to use for TLS
     // connections. The certificate should be in X.509 PEM format.
@@ -194,10 +196,12 @@ open class CoderSettings(
     val defaultSignatureNameByOsAndArch: String get() = getCoderSignatureForOS(getOS(), getArch())
 
     /**
-     * A command to run to set headers for API calls.
+     * A command to run to set headers for API calls. Falls back to the
+     * CODER_HEADER_COMMAND environment variable (the same variable the Coder
+     * CLI reads) when the setting is blank.
      */
     val headerCommand: String
-        get() = state.headerCommand
+        get() = state.headerCommand.ifBlank { env.get(CODER_HEADER_COMMAND) }
 
     /**
      * Whether to disable automatically starting a workspace when connecting.

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -83,7 +83,8 @@ gateway.connector.settings.header-command.title=Header command
 gateway.connector.settings.header-command.comment=An external command that \
   outputs additional HTTP headers added to all requests. The command must \
   output each header as `key=value` on its own line. The following \
-  environment variables will be available to the process: CODER_URL.
+  environment variables will be available to the process: CODER_URL. If left \
+  blank the environment variable {0} will be used, if set.
 gateway.connector.settings.tls-cert-path.title=Cert path
 gateway.connector.settings.tls-cert-path.comment=Optionally set this to \
   the path of a certificate to use for TLS connections. The certificate \

--- a/src/main/resources/messages/CoderGatewayBundle.properties
+++ b/src/main/resources/messages/CoderGatewayBundle.properties
@@ -82,9 +82,8 @@ gateway.connector.settings.fallback-on-coder-for-signatures.comment=Verify binar
 gateway.connector.settings.header-command.title=Header command
 gateway.connector.settings.header-command.comment=An external command that \
   outputs additional HTTP headers added to all requests. The command must \
-  output each header as `key=value` on its own line. The following \
-  environment variables will be available to the process: CODER_URL. If left \
-  blank the environment variable {0} will be used, if set.
+  output each header as `key=value` on its own line. When this setting is \
+  left blank, the environment variable {0} is used instead, if set.
 gateway.connector.settings.tls-cert-path.title=Cert path
 gateway.connector.settings.tls-cert-path.comment=Optionally set this to \
   the path of a certificate to use for TLS connections. The certificate \

--- a/src/test/kotlin/com/coder/gateway/settings/CoderSettingsTest.kt
+++ b/src/test/kotlin/com/coder/gateway/settings/CoderSettingsTest.kt
@@ -244,6 +244,27 @@ internal class CoderSettingsTest {
     }
 
     @Test
+    fun testHeaderCommand() {
+        var settings = CoderSettings(CoderSettingsState(headerCommand = "header command from state"))
+        assertEquals("header command from state", settings.headerCommand)
+
+        settings =
+            CoderSettings(
+                CoderSettingsState(),
+                env = Environment(mapOf(CODER_HEADER_COMMAND to "header command from env")),
+            )
+        assertEquals("header command from env", settings.headerCommand)
+
+        // State has precedence.
+        settings =
+            CoderSettings(
+                CoderSettingsState(headerCommand = "header command from state"),
+                env = Environment(mapOf(CODER_HEADER_COMMAND to "header command from env")),
+            )
+        assertEquals("header command from state", settings.headerCommand)
+    }
+
+    @Test
     fun testSSHConfigOptions() {
         var settings = CoderSettings(CoderSettingsState(sshConfigOptions = "ssh config options from state"))
         assertEquals("ssh config options from state", settings.sshConfigOptions)


### PR DESCRIPTION
The Coder CLI reads `CODER_HEADER_COMMAND` from the environment, and the VS Code extension falls back to it when `coder.headerCommand` is unset ([`src/settings/headers.ts`](https://github.com/coder/vscode-coder/blob/main/src/settings/headers.ts)). The Gateway plugin only honours its own setting, so on deployments behind an authenticating proxy every user has to paste the command into Settings by hand even when their environment already carries it.

This makes `CoderSettings.headerCommand` fall back to `CODER_HEADER_COMMAND` when the setting is blank — the same pattern `sshConfigOptions` already uses with `CODER_SSH_CONFIG_OPTIONS`, through the existing `Environment` seam. All consumers (REST client headers, the CLI exec environment, the `--header-command` written into the SSH config) read through that getter, so no call sites change. The settings UI comment now names the variable, like the SSH-options one does. An explicitly configured setting still wins.

Test: `CoderSettingsTest.testHeaderCommand` (state / env / precedence), mirroring `testSSHConfigOptions`.

Toolbox counterpart: coder/coder-jetbrains-toolbox#350